### PR TITLE
Standardize nextseq symlink ordering

### DIFF
--- a/scripts/flowcells/link_nextseq.py
+++ b/scripts/flowcells/link_nextseq.py
@@ -65,7 +65,7 @@ def create_links(lane, read, input_basedir, output_basedir, dry_run = False, und
     # This will fail if we have the same sample listed multiple times in the
     # samplesheet (run with different barcodes). 
     # But I've never seen that happen.
-    input_fastq = glob.glob(input_wildcard)
+    input_fastq = sorted(glob.glob(input_wildcard))
 
     for idx, input_file in enumerate(input_fastq, start=1):
         output_name = "%s_%s_%03d.fastq.gz" % (sample_name, read, idx)


### PR DESCRIPTION
In some cases, glob.glob() returns stuff off the filesystem in a
non-sorted order. This meant that L001_R1_003 didn't necessarily link to
L003_R1_001. This didn't affect anything downstream, but adding sorting
makes it behave more as you'd expect.
