### PR TITLE
Fix for '_' to '-' replacement in bcl2fastq2

### DIFF
--- a/scripts/flowcells/link_nextseq.py
+++ b/scripts/flowcells/link_nextseq.py
@@ -53,6 +53,7 @@ def create_links(lane, read, input_basedir, output_basedir, dry_run = False, und
 
     # if nextseq
     if True:
+        short_name = re.sub(r"_", '-', short_name)
         input_dir  = input_basedir
         input_wildcard = os.path.join(input_dir, "%s_S*_L00?_%s_???.fastq.gz" % (short_name, read))
     else: # eventually could be highseq rapid run linking... have to make some changes


### PR DESCRIPTION
bcl2fastq2 seems to convert underscores in sample names to hyphens (dashes? whaterver this '-' is).
