### PR TITLE
Standardize nextseq Undetermined naming schema

### DIFF
--- a/scripts/flowcells/link_nextseq.py
+++ b/scripts/flowcells/link_nextseq.py
@@ -101,7 +101,7 @@ from the command line."""
         create_links(lane, "R1", input_dir, poptions.output_dir, poptions.dry_run)
         create_links(lane, "R2", input_dir, poptions.output_dir, poptions.dry_run)
 
-    undet_lane = {"alignments":[{"sample_name": "lane1_Undetermined"}], "samplesheet_name": "Undetermined" }
+    undet_lane = {"alignments":[{"sample_name": "lane1_Undetermined_L001"}], "samplesheet_name": "Undetermined" }
     for read in ['R1', 'R2']:
         create_links(undet_lane, read, input_dir, poptions.output_dir, poptions.dry_run, True)
 


### PR DESCRIPTION
Specifically, include the L001 bit, to bring in line with bcl2fastq v1.8
naming schema.
