### PR TITLE
Quick fix for bamcounts

### DIFF
--- a/scripts/bwa/bamcounts.py
+++ b/scripts/bwa/bamcounts.py
@@ -62,7 +62,7 @@ class BAMFilter(object):
         # do not use reads with
         # 0x4 = read is unmapped
         # 0x8 = pair is unmapped
-        if read.flag | 12:
+        if read.flag & 12:
             return False
 
         if read.is_unmapped:


### PR DESCRIPTION
Need to & with flag, |'ing with a constant is always true. This meant we were getting 0-counts for "properly-paired aligning reads."
