### PR TITLE
Barcodes automask

### DIFF
--- a/scripts/flowcells/barcode_masks.py
+++ b/scripts/flowcells/barcode_masks.py
@@ -1,0 +1,122 @@
+
+import os, sys, re
+import json
+import argparse
+import logging
+
+MAX_BARCODE_LENGTH = 8 
+
+script_options = {
+    "processing": "processing.json"
+}
+
+def parser_setup():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--processing", dest="processing",
+            help="The JSON file to read barcodes from")
+
+    parser.set_defaults( **script_options )
+    return parser
+
+
+# Generates the barcode reporting mask from processing.json
+# Returns a list of all barcode lengths represented in the data
+def get_barcode_masks(json_data):
+    masks = []
+    read_length = json_data["flowcell"]["read_length"]
+    barcode_lengths = get_barcode_lengths(json_data)
+
+    # determines the n's in the mask
+    def format_difference(x):
+        if MAX_BARCODE_LENGTH - int(x) == 0:
+            return ""
+        else:
+            return "n" + str(MAX_BARCODE_LENGTH - int(x))
+
+    for length in barcode_lengths:
+        parts = length.split("-")
+
+        for i, x in enumerate(parts):
+            if x == "0":
+                parts[i] = "n" + str(MAX_BARCODE_LENGTH - int(x))
+            else:
+                parts[i] = "i{}{}".format(x, format_difference(x))
+
+        mask = "y{0},{1},{2},y{0}".format(read_length, parts[0], parts[1])
+        masks.append(mask)
+    
+    return masks
+
+
+# Determines how many different sizes of barcodes there are and returns a set of them
+def get_barcode_lengths(json_data):
+    # in case barcode sequence is null
+    def format_length(x):
+        if (x):
+            return len(x["sequence"])
+        else:
+            return '0'
+
+    # set of each unique length in the data
+    lengths = set([ "{}-{}".format(
+        format_length(lib["barcode1"]), 
+        format_length(lib["barcode2"])) 
+        for lib in json_data["libraries"] ])
+
+    # Make sure only 1 report is run each for single/dual indexed barcodes until reporting is more flexible
+    tempbc1, tempbc2 = [], []
+    finalList = []
+
+    for n in lengths:
+        if n[2] == '0':
+            tempbc1.append(n)
+        else:
+            tempbc2.append(n)
+
+    finalList.append(sorted(tempbc1)[0])
+    if tempbc2 != []:
+        finalList.append(sorted(tempbc2)[0])
+    
+    return finalList
+
+
+# Detects if there are barcode collisions per lane
+# TODO add support for multiple resolutions, i.e. collision w/ barcode 8bp long and mask i6n2,n8 might not collide @ i8,n8 
+def detect_collisions(json_data):
+    num_lanes = max([ lib["lane"] for lib in json_data["libraries"] ])
+    
+    for i in range(num_lanes):
+        barcodes = [ lib["barcode_index"] for lib in json_data["libraries"] if lib["lane"] == i+1]
+        if (len(barcodes) != len(set(barcodes))):
+            collision = []
+            [collision.append(barcode) for i, barcode in sorted(enumerate(barcodes)) if barcode == barcodes[i-1]]
+            logging.error("Collision on lane {}. Barcode(s): {}\n".format(i+1, collision))
+            sys.exit(1)
+            return True
+    return False
+
+
+# Returns an array of barcode report masks
+# Also detects barcode collisions for each mask
+def main():
+    """This is the main body of the program that by default uses the arguments
+    from the command line."""
+
+    # Parse args
+    parser = parser_setup()
+    poptions = parser.parse_args()
+
+    # Read JSON
+    process_json = open(poptions.processing)
+    json_data = json.load(process_json)
+    process_json.close()
+    
+    detect_collisions(json_data)
+    print(" ".join(get_barcode_masks(json_data)))
+    
+
+# This is the main body of the program that only runs when running this script
+# doesn't run when imported, so you can use the functions above in the shell after importing
+# without automatically running it
+if __name__ == "__main__":
+    main()

--- a/scripts/flowcells/setup.sh
+++ b/scripts/flowcells/setup.sh
@@ -313,9 +313,9 @@ while [ ! -e "$illumina_dir/RTAComplete.txt" ] ; do sleep 60 ; done
 # Submit a barcode job for each mask
 for bcmask in $(python $STAMPIPES/scripts/flowcells/barcode_masks.py | xargs) ; do
     qsub -cwd -N "bc-$flowcell" -pe threads 4-8 -V -S /bin/bash <<'__BARCODES__'
-    GOMAXPROCS=\$(( NSLOTS * 2 )) bcl_barcode_count --mask=\$bcmask $bc_flag > barcodes.json
+    GOMAXPROCS=\$(( NSLOTS * 2 )) bcl_barcode_count --mask=\$bcmask $bc_flag > barcodes.$bcmask.json
 
-    python3 $STAMPIPES/scripts/lims/upload_data.py --barcode_report barcodes.json
+    python3 $STAMPIPES/scripts/lims/upload_data.py --barcode_report barcodes.$bcmask.json
 __BARCODES__
 done
 

--- a/scripts/flowcells/setup.sh
+++ b/scripts/flowcells/setup.sh
@@ -300,17 +300,17 @@ module load bcl2fastq2/2.15.0.4
 source $PYTHON3_ACTIVATE
 
 
- # Register the file directory
- python3 "$STAMPIPES/scripts/lims/upload_data.py" \
-   --attach_directory "$analysis_dir" \
-   --attach_file_contenttype sequencingdata.flowcellrun \
-   --attach_file_purpose flowcell-directory \
-   --attach_file_objectid $flowcell_id
+# Register the file directory
+python3 "$STAMPIPES/scripts/lims/upload_data.py" \
+  --attach_directory "$analysis_dir" \
+  --attach_file_contenttype sequencingdata.flowcellrun \
+  --attach_file_purpose flowcell-directory \
+  --attach_file_objectid $flowcell_id
 
 
 while [ ! -e "$illumina_dir/RTAComplete.txt" ] ; do sleep 60 ; done
 
-# temporary path
+# Submit a barcode job for each mask
 for bcmask in $(python $STAMPIPES/scripts/flowcells/barcode_masks.py | xargs) ; do
     qsub -cwd -N "bc-$flowcell" -pe threads 4-8 -V -S /bin/bash <<'__BARCODES__'
     GOMAXPROCS=\$(( NSLOTS * 2 )) bcl_barcode_count --mask=\$bcmask $bc_flag > barcodes.json


### PR DESCRIPTION
Changes setup.sh to automatically detect barcode masks, and to run a report for each.

* Currently returns a maximum of 2 masks, one for single-indexed barcodes and one for dual-indexed barcodes if processing.json contains any.

* Detects collisions per-lane upon running setup.sh