### PR TITLE
(fix) set chkchr to first chromosome in chromInfo.bed

### DIFF
--- a/scripts/SPOT/runhotspot.bash
+++ b/scripts/SPOT/runhotspot.bash
@@ -36,7 +36,7 @@ echo "Creating $CONFIGOUT"
 
 chromFile=$(readlink -f "$GENOME.chromInfo.bed")
 mappableFile=$(readlink -f "$GENOME.K$K.mappable_only.bed")
-chkchr=$(awk 'BEGIN {print $1}' < "$chromFile")
+chkchr=$(awk 'NR==1{print $1}' < "$chromFile")
 
 # Create the configuration file for the SPOT program
 cat > $CONFIGOUT <<EOF


### PR DESCRIPTION
The original awk does not, I think, work

chromFile=home/solexa/stampipes/data/annotations/GRCh38_no_alts.chromInfo.bed

(production) (base) solexa@dev0 01:41:53 /tmp/tmp.wMptRMPA7T $ awk 'BEGIN {print $1}' < "$chromFile"

(production) (base) solexa@dev0 01:42:02 /tmp/tmp.wMptRMPA7T $ awk 'NR==1{print $1}' < "$chromFile"
chr1