### PR TITLE
DNase: upload multiply-mapping density files

### DIFF
--- a/processes/bwa/aggregate/basic.bash
+++ b/processes/bwa/aggregate/basic.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version=2.5.0
+version=2.5.1
 export NXF_VER=18.10.1  # The version of nextflow to run. 18.10.1 includes conda
 
 cd "$(dirname "$0")"

--- a/scripts/bwa/aggregate/basic/attachfiles_nextflow.bash
+++ b/scripts/bwa/aggregate/basic/attachfiles_nextflow.bash
@@ -1,9 +1,7 @@
 # Uploads important files as attachments to an aggregation object on the LIMS
 # Required environment names:
 #  * STAMPIPES
-#  * LIBRARY_NAME
-#  * GENOME
-#  * AGGREGATION_DIR
+#  * PEAK_CALLER
 #  * AGGREGATION_ID
 
 set -e -u -o pipefail
@@ -31,12 +29,16 @@ attach_file  marked.bam      all-alignments-bam  bam
 attach_file  marked.bam.bai  bam-index           bam-index
 
 # Densities
-attach_file  density.starch             density-bed-starch-windowed         starch
-attach_file  density.bw                 density-bigwig-windowed             bigwig
-attach_file  density.bgz                density-tabix-bgz                   bgz
-attach_file  normalized.density.starch  normalized-density-bed-starch       starch
-attach_file  normalized.density.bw      normalized-density-bigwig-windowed  bigwig
-attach_file  normalized.density.bgz     normalized-density-tabix-bgz        bgz
+attach_file  density.starch                density-bed-starch-windowed            starch
+attach_file  density.bw                    density-bigwig-windowed                bigwig
+attach_file  density.bgz                   density-tabix-bgz                      bgz
+attach_file  normalized.density.starch     normalized-density-bed-starch          starch
+attach_file  normalized.density.bw         normalized-density-bigwig-windowed     bigwig
+attach_file  normalized.density.bgz        normalized-density-tabix-bgz           bgz
+attach_file  mm_density.starch             mm-density-bed-starch-windowed         starch
+attach_file  mm_density.bw                 mm-density-bigwig-windowed             bigwig
+attach_file  normalized.mm_density.starch  normalized-mm-density-bed-starch       starch
+attach_file  normalized.mm_density.bw      normalized-mm-density-bigwig-windowed  bigwig
 
 # Cut counts
 attach_file  cutcounts.bw       cutcounts-bw         bigwig


### PR DESCRIPTION
This fixes SE-1340, and enables users to view multiply-mapping files in our
browser with Track Designer.