### PR TITLE
Fix RNA for non-human alignments

### DIFF
--- a/processes/rna-star/modules/star.nf
+++ b/processes/rna-star/modules/star.nf
@@ -1,7 +1,6 @@
 nextflow.enable.dsl=2
 
 params.star_threads = 8
-params.starIndexDir = ""
 params.publish = true
 
 process star {

--- a/processes/rna-star/star_alignment.nf
+++ b/processes/rna-star/star_alignment.nf
@@ -9,8 +9,7 @@ params.adapter_p7 = null
 params.readlength = null
 params.umimethod = null
 
-params.refdir = "/net/seq/data/genomes/human/GRCh38/noalts-sequins/"
-starIndexDir = "${params.refdir}/STARgenome-gencode-v25"
+params.starIndexDir = "/net/seq/data/genomes/human/GRCh38/noalts-sequins/STARgenome-gencode-v25"
 params.star_threads = 8
 
 


### PR DESCRIPTION
A coding error meant we always used GRCh38, regardless of specified
index.

This actually turned out to be an embarrassingly easy fix (just rename the parameter) - It'll complicate the CRAM branch a tiny bit, but not too much.