### PR TITLE
Remove Anaquin from RNA-seq processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Modules
 
 The current modules to load for working the pipeline are:
 
-* `anaquin/2.0.1`
 * `bcl2fastq/1.8.4`
 * `bcl2fastq2/2.15.0.4`
 * `bedops/2.4.35-typical`

--- a/processes/rna-star/aggregation/cufflinks_featurecounts.nf
+++ b/processes/rna-star/aggregation/cufflinks_featurecounts.nf
@@ -67,7 +67,7 @@ workflow RNA_AGG {
 
   kallisto(fastq, kallisto_index, sequins_iso_mix)
   kallisto_advanced(fastq, kallisto_index, sequins_iso_mix)
-  anaquin(bam_to_use, sequins_ref, kallisto_index, neat_mix_A, sequins_iso_mix)
+  // anaquin(bam_to_use, sequins_ref, kallisto_index, neat_mix_A, sequins_iso_mix)
 
   // QC Metrics
   insert_sizes(bam_to_use)
@@ -276,7 +276,7 @@ process density {
 process cufflinks {
 
   publishDir params.outdir, mode: params.publishmode
-  module "cufflinks/2.2.1", "R/3.2.5", "anaquin/2.0.1"
+  module "cufflinks/2.2.1", "R/3.2.5"
 
   input:
     path input_bam
@@ -285,7 +285,7 @@ process cufflinks {
 
 
   output:
-    tuple path("genes.fpkm_tracking"), path("isoforms.fpkm_tracking"), path("anaquin_cufflinks/*")
+    tuple path("genes.fpkm_tracking"), path("isoforms.fpkm_tracking")
     path "skipped.gtf"
     path "transcripts.gtf"
 
@@ -304,11 +304,11 @@ process cufflinks {
     mv genes.fpkm_tracking.sort genes.fpkm_tracking
     mv isoforms.fpkm_tracking.sort isoforms.fpkm_tracking
 
-    # quantification with anaquin Rna Expression
-    anaquin RnaExpression -o anaquin_cufflinks -rmix "$sequins_iso_mix" -usequin transcripts.gtf -mix A \
-    || (echo "NA" > anaquin_cufflinks/RnaExpression_genes.tsv \
-     && echo "NA" > anaquin_cufflinks/RnaExpression_isoforms.tsv \
-     && echo "NA" > anaquin_cufflinks/RnaExpression_summary.stats)
+    # # quantification with anaquin Rna Expression
+    # anaquin RnaExpression -o anaquin_cufflinks -rmix "$sequins_iso_mix" -usequin transcripts.gtf -mix A \
+    # || (echo "NA" > anaquin_cufflinks/RnaExpression_genes.tsv \
+    #  && echo "NA" > anaquin_cufflinks/RnaExpression_isoforms.tsv \
+    #  && echo "NA" > anaquin_cufflinks/RnaExpression_summary.stats)
     """
 
 }
@@ -359,7 +359,7 @@ process feature_counts {
 process kallisto {
 
   publishDir params.outdir, mode: params.publishmode
-  module "kallisto/0.43.1", "anaquin/2.0.1"
+  module "kallisto/0.43.1"
 
   input:
     tuple path(r1_fq), path(r2_fq)
@@ -367,7 +367,6 @@ process kallisto {
     path sequins_iso_mix
 
   output:
-    path "anaquin_kallisto/*"
     path "kallisto_output/*"
     path "kallisto.log"
 
@@ -375,17 +374,17 @@ process kallisto {
     """
     kallisto quant -i "${kallisto_index}" -o kallisto_output "${r1_fq}" "${r2_fq}" 2> kallisto.log
 
-    anaquin RnaExpression -o anaquin_kallisto -rmix "${sequins_iso_mix}" -usequin kallisto_output/abundance.tsv -mix A \
-    || (echo "NA" > anaquin_kallisto/RnaExpression_genes.tsv \
-     && echo "NA" > anaquin_kallisto/RnaExpression_isoforms.tsv \
-     && echo "NA" > anaquin_kallisto/RnaExpression_summary.stats)
+    #anaquin RnaExpression -o anaquin_kallisto -rmix "${sequins_iso_mix}" -usequin kallisto_output/abundance.tsv -mix A \
+    #|| (echo "NA" > anaquin_kallisto/RnaExpression_genes.tsv \
+    # && echo "NA" > anaquin_kallisto/RnaExpression_isoforms.tsv \
+    # && echo "NA" > anaquin_kallisto/RnaExpression_summary.stats)
     """
 }
 
 process kallisto_advanced {
   
   publishDir params.outdir, mode: params.publishmode
-  module "kallisto/0.43.1", "anaquin/2.0.1"
+  module "kallisto/0.43.1"
 
   input:
     tuple path(r1_fq), path(r2_fq)
@@ -393,7 +392,6 @@ process kallisto_advanced {
     path sequins_iso_mix
 
   output:
-    path "anaquin_kallisto_adv/*"
     path "kallisto_output_adv/*"
     path "kallisto_adv.log"
 
@@ -401,10 +399,10 @@ process kallisto_advanced {
     """
     kallisto quant --bias -b 100 --rf-stranded -i "${kallisto_index}" -o kallisto_output_adv "${r1_fq}" "${r2_fq}" 2> kallisto_adv.log
 
-    anaquin RnaExpression -o anaquin_kallisto_adv -rmix "${sequins_iso_mix}" -usequin kallisto_output_adv/abundance.tsv -mix A \
-    || (echo "NA" > anaquin_kallisto_adv/RnaExpression_genes.tsv \
-     && echo "NA" > anaquin_kallisto_adv/RnaExpression_isoforms.tsv \
-     && echo "NA" > anaquin_kallisto_adv/RnaExpression_summary.stats)
+    # anaquin RnaExpression -o anaquin_kallisto_adv -rmix "${sequins_iso_mix}" -usequin kallisto_output_adv/abundance.tsv -mix A \
+    # || (echo "NA" > anaquin_kallisto_adv/RnaExpression_genes.tsv \
+    #  && echo "NA" > anaquin_kallisto_adv/RnaExpression_isoforms.tsv \
+    #  && echo "NA" > anaquin_kallisto_adv/RnaExpression_summary.stats)
     """
 }
 

--- a/processes/rna-star/aggregation/cufflinks_featurecounts.sh
+++ b/processes/rna-star/aggregation/cufflinks_featurecounts.sh
@@ -1,4 +1,4 @@
-VERSION=1.1
+VERSION=1.2
 OUT_DIR=output_$VERSION
 mkdir -p "$OUT_DIR"
 

--- a/scripts/rna-star/aggregate/concat_metrics.sh
+++ b/scripts/rna-star/aggregate/concat_metrics.sh
@@ -18,23 +18,4 @@ rm -f metrics.info
     cat ribosomal_counts.info | grep 'ribosomal'
     cat adapter_counts.info | grep 'adapter'
 
-    if [ -s anaquin_star/RnaAlign_summary.stats.info ]; then
-        cat anaquin_star/RnaAlign_summary.stats.info | grep 'sequins-dilution'
-        cat anaquin_star/RnaAlign_summary.stats.info | grep 'sequins-base-level-sensitivity'
-        cat anaquin_star/RnaAlign_summary.stats.info | grep 'sequins-base-level-precision'
-    fi
-
-    if [ -s anaquin_subsample/anaquin_kallisto/RnaExpression_isoforms.neatmix.tsv.info ]; then
-        cat anaquin_subsample/anaquin_kallisto/RnaExpression_isoforms.neatmix.tsv.info | grep 'neat-mixA-mean-spearman'
-    fi
-
-    if [ -s anaquin_subsample/anaquin_kallisto/RnaExpression_summary.stats.info ]; then
-        cat anaquin_subsample/anaquin_kallisto/RnaExpression_summary.stats.info | grep 'sequins-isoforms-log2-pearson-cor'
-        cat anaquin_subsample/anaquin_kallisto/RnaExpression_summary.stats.info | grep 'sequins-genes-slope'
-        cat anaquin_subsample/anaquin_kallisto/RnaExpression_summary.stats.info | grep 'sequins-genes-log2-pearson-cor'
-        cat anaquin_subsample/anaquin_kallisto/RnaExpression_summary.stats.info | grep 'sequins-percent-isoforms-found'
-        cat anaquin_subsample/anaquin_kallisto/RnaExpression_summary.stats.info | grep 'sequins-percent-genes-found'
-        cat anaquin_subsample/anaquin_kallisto/RnaExpression_summary.stats.info | grep 'sequins-detection-sensitivity-isoforms'
-        cat anaquin_subsample/anaquin_kallisto/RnaExpression_summary.stats.info | grep 'sequins-detection-sensitivity-genes'
-    fi
 } > metrics.info

--- a/scripts/rna-star/aggregate/reset.bash
+++ b/scripts/rna-star/aggregate/reset.bash
@@ -44,12 +44,7 @@ files=( \
 )
 
 dirs=( \
-    "anaquin_cufflinks"     \
-    "anaquin_kallisto"      \
-    "anaquin_kallisto_adv"  \
-    "anaquin_star"          \
     "kallisto_output"       \
-    "anaquin_subsample"     \
     "kallisto_output_adv"   \
 )
 

--- a/scripts/versions.bash
+++ b/scripts/versions.bash
@@ -88,11 +88,6 @@ echo "R:"
 R --version | grep "R version"
 fi
 
-if [[ `command -v anaquin` ]]; then
-echo "Anaquin:"
-anaquin | grep 'Version'
-fi
-
 if [[ `command -v tabix` ]]; then
 echo "Tabix/BGZIP:"
 which tabix | sed -e 's/.*htslib\///g' | sed -e 's/\/bin\/tabix//g'


### PR DESCRIPTION
This disables Anaquin from the RNA-STAR pipeline and bumps the version to 1.2.
This change is unilateral, and does not do Anaquin processing even for libraries that have sequins.

Justification: We are no longer sequencing libraries with sequins, and sometimes these steps take a very long time.

