### PR TITLE
Fix for NovaSeq run type

### DIFF
--- a/scripts/flowcells/setup.sh
+++ b/scripts/flowcells/setup.sh
@@ -202,7 +202,7 @@ run_type=$(     jq -r '.flowcell.run_type'          "$json" )
 has_umi=$(      jq -r '.libraries | map(.barcode1.umi) | any' "$json")
 
 # Novaseq runs always use native bcl2fastq demuxing
-if [[ $run_type =~ Novaseq ]] ; then
+if [[ $run_type =~ Novaseq ]] || [[ $run_type =~ NovaSeq ]] ; then
   unset demux
 fi
 


### PR DESCRIPTION
The newer sequencers use the `NovaSeq` run type instead of `Novaseq`. This change fixes the check so that we properly don't use the demux_fastq.py for those flowcells.

I'm tagging you in this Richard, just in case you want to review it. If I don't hear from you, I'll probably merge it today or tomorrow.