### PR TITLE
Feat/fast demuxing

### DIFF
--- a/scripts/flowcells/setup.sh
+++ b/scripts/flowcells/setup.sh
@@ -301,7 +301,7 @@ read -d '' novaseq_submit_command <<_NOVA_SUBMIT_CMD_
 PROCESSING=
 for samplesheet in SampleSheet.withmask*csv ; do
   for lane in {1..8} ; do
-    # TODO: Skip submission if lane not in this samplesheet
+    # Skip submission if lane not in this samplesheet
     if ! (cut -d, -f1 \$samplesheet | sort -u | grep -q \$lane) ; then
       echo "Lane \$lane not in samplesheet \$samplesheet, skipping"
       continue


### PR DESCRIPTION
This change speeds up processing significantly - we run one job for each
Samplesheet.csv / lane combination, rather than one big long job. We
also give each job 40 cores, instead of 20.  If a lane does not exist in a given samplesheet (which happens occasionally), it should be skipped.

Non-Novaseq processing should be unchanged, but has been only tested lightly. If it gives you any guff while I'm out, consider running the version of this script from before this PR.


Happy to walk through these changes today if you'd like. :)