### PR TITLE
Fix for copy for Flowcells without samples

### DIFF
--- a/scripts/flowcells/setup.sh
+++ b/scripts/flowcells/setup.sh
@@ -804,6 +804,7 @@ rsync -avP "$illumina_dir"/SampleSheet*.csv "$analysis_dir/"
 (
     cd "$copy_from_dir"
     for dir in Project*/Sample* ; do
+        [[ -d \$dir ]] || continue
         samp_number=\$(sed 's/.*DS\([0-9]*\).*/\1/' <<< "\$dir")
         [[ -n "\$samp_number" ]]
         destination=\$(jq -c -r ".libraries[] | select(.sample == \$samp_number) | .project_share_directory" ../processing.json)


### PR DESCRIPTION
Some flowcells have only LibraryPools, and no traditional samples. This change should fix processing for those flowcells so that they no longer fail to copy.

This uses the same logic that we use to skip LibraryPools copying if none of those exist. 

Explanation: The issue is that if the glob fails to match any files, it makes one iteration through the loop, with `$dir` set to the glob. Because `set -e` is on, the script would exit when it encountered an error later trying to process this non-directory.

(`[[ -d $dir ]] || continue` is bash for "if the string in $dir is not the name of a directory, go to the next iteration of the loop")