### PR TITLE
Feat/fastq container

### DIFF
--- a/containers/fastq/fastq.def
+++ b/containers/fastq/fastq.def
@@ -18,9 +18,8 @@ From: rockylinux:8.6
 	set -e
 	dnf install -y python39
 	ln -s /usr/bin/python3 /usr/bin/python
-	ls /opt/stamlims_api/
-
 	python -m pip install /opt/stamlims_api/
+	python -m pip install Biopython
 	dnf install -y rsync
 
 	# install fastqc

--- a/containers/fastq/fastq.def
+++ b/containers/fastq/fastq.def
@@ -1,0 +1,47 @@
+Bootstrap: docker
+From: rockylinux:8.6
+
+%arguments
+	FASTQC_VERSION=v0.11.5
+
+%help
+	This container contains the necessary software to run the first stage of
+	the pipeline, beginning from retriving metadata from LIMS, running
+	bcl2fastq and demultiplexing, collating fastq files, running FastQC, and
+	registering output with LIMS.
+
+%files
+	./bcl2fastq /usr/local/bin/bcl2fastq
+	../../scripts/lims/stamlims_api /opt/
+
+%post
+	set -e
+	dnf install -y python39
+	ln -s /usr/bin/python3 /usr/bin/python
+	ls /opt/stamlims_api/
+
+	python -m pip install /opt/stamlims_api/
+	dnf install -y rsync
+
+	# install fastqc
+	# https://github.com/s-andrews/FastQC/
+	(
+		dnf install -y unzip perl java
+		cd /opt 
+		curl https://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_{{ FASTQC_VERSION }}.zip --output fastqc.zip
+		unzip fastqc.zip
+		rm fastqc.zip
+		chmod +x FastQC/fastqc
+		ln -s /opt/FastQC/fastqc /usr/local/bin/fastqc
+	)
+
+
+%test
+	set -e
+	bcl2fastq --version
+	rsync --version
+	fastqc --version
+	gzip --version
+	python3 --version
+
+# vim: noexpandtab ts=4 sts=4 sw=4

--- a/processes/fastq/fastqc.bash
+++ b/processes/fastq/fastqc.bash
@@ -1,8 +1,10 @@
 # Dependencies
 [[ -s "$MODULELOAD" ]] && source "$MODULELOAD"
+{
 module load jdk/1.8.0_92
 module load picard/2.8.1
 module load fastqc/0.11.5
+} || true # ignore module load failures
 
 export FASTQ_NAME=${FLOWCELL}_${SAMPLE_NAME}
 export R1_FASTQ=${FASTQ_NAME}_R1.fastq.gz
@@ -52,7 +54,7 @@ if [ ! -e "$R1_FASTQC" -o ! -e "$R2_FASTQC" ]; then
 	  --fastqcfile $R1_FASTQC
   fi
 
-  bash $STAMPIPES/scripts/fastq/attachfiles.bash
+  $APX bash $STAMPIPES/scripts/fastq/attachfiles.bash
 
   echo "FINISH: "
   date

--- a/scripts/flowcells/setup.sh
+++ b/scripts/flowcells/setup.sh
@@ -298,7 +298,7 @@ fi
 set +e
 read -d '' regular_bcl_command  << _REG_BCL_CMD_
     PATH=/home/nelsonjs/src/bcl2fastq2/bin/:\$PATH
-    bcl2fastq \\\\
+    \$APX bcl2fastq \\\\
       --input-dir "${illumina_dir}/Data/Intensities/BaseCalls" \\\\
       --use-bases-mask "$bcl_mask" \\\\
       --output-dir "$fastq_dir" \\\\
@@ -313,7 +313,7 @@ read -d '' novaseq_bcl_command  << _NOVA_BCL_CMD_
     for samplesheet in SampleSheet.withmask*csv ; do
       bcl_mask=\$(sed 's/.*withmask\\.//;s/\\.csv//' <<< \$samplesheet)
       fastq_dir=\$(sed 's/,/-/g' <<< "fastq-withmask-\$bcl_mask")
-      bcl2fastq \\\\
+      \$APX bcl2fastq \\\\
         --input-dir          "${illumina_dir}/Data/Intensities/BaseCalls" \\\\
         --output-dir         "${illumina_dir}/\$fastq_dir"                \\\\
         --use-bases-mask     "\$bcl_mask"                                 \\\\
@@ -348,7 +348,7 @@ for samplesheet in SampleSheet.withmask*csv ; do
       set -x -e -o pipefail
       cd "${illumina_dir}"
       PATH=/home/nelsonjs/src/bcl2fastq2/bin/:\$PATH
-      bcl2fastq \\\\
+      \$APX bcl2fastq \\\\
         --input-dir          "${illumina_dir}/Data/Intensities/BaseCalls" \\\\
         --output-dir         "${illumina_dir}/\\\$fastq_dir"              \\\\
         --use-bases-mask     "\\\$bcl_mask"                               \\\\
@@ -544,7 +544,7 @@ case $run_type in
     bcl_tasks=1
     set +e
     read -d '' unaligned_command  << _U_
-    bcl2fastq \\\\
+    \$APX bcl2fastq \\\\
       --input-dir "${illumina_dir}/Data/Intensities/BaseCalls" \\\\
       --output-dir "$fastq_dir" \\\\
       --create-fastq-for-index-reads
@@ -565,7 +565,7 @@ _U_
     bcl_tasks=1
     set +e
     read -d '' unaligned_command  << _U_
-    bcl2fastq \\\\
+    \$APX bcl2fastq \\\\
       --input-dir "${illumina_dir}/Data/Intensities/BaseCalls" \\\\
       --output-dir "$fastq_dir" \\\\
       --no-lane-splitting
@@ -588,7 +588,7 @@ _U_
     bcl_tasks=1
     set +e
     read -d '' unaligned_command  << _U_
-    bcl2fastq \\\\
+    \$APX bcl2fastq \\\\
       --input-dir "${illumina_dir}/Data/Intensities/BaseCalls" \\\\
       --output-dir "$fastq_dir" \\\\
       --no-lane-splitting
@@ -733,13 +733,14 @@ cat > run_bcl2fastq.sh <<__BCL2FASTQ__
 
 [[ -s "$MODULELOAD" ]] && source "$MODULELOAD"
 module load bcl2fastq2/2.20.0.422
-\$LOAD_APPTAINER
 [[ -s "$PYTHON3_ACTIVATE" ]] && source "$PYTHON3_ACTIVATE"
 source $STAMPIPES/scripts/lims/api_functions.sh
 
 $(declare -f on_new_cluster)
 $(declare -f set_cluster_vars)
 set_cluster_vars
+
+\$LOAD_APPTAINER
 
 # Register the file directory
 \$APX python3 "$STAMPIPES/scripts/lims/upload_data.py" \


### PR DESCRIPTION
This PR contains the necessary work for us to be able to run on the new SLURM cluster for the initial stages of the pipeline - bcl2fastq (including demultiplexing), copying, collation, and fastqc.

When these scripts are run on the new cluster, the new apptainer image at `$STAMPIPES/containers/fastq/fastq.sif` will be used for any step which requires python or a more specialized software (bcl2fastq, fastqc). When run on the old cluster, we use the module system as usual.

At the end of the build, if we are on the new cluster, we ssh to the old cluster to run `run_alignments.bash` and `run_pools.sh`, as these are not yet ported to the new cluster.