### PR TITLE
Fix: fastqc/alignments/pools wait for collation

### DIFF
--- a/scripts/flowcells/setup.sh
+++ b/scripts/flowcells/setup.sh
@@ -922,7 +922,7 @@ rm -f fastqc.bash collate.bash run_alignments.bash run_aggregations.bash run_poo
 bash collate.bash
 
 # Wait for collation jobs to finish
-while ( squeue -o "%j" | grep -q '^.collatefq*$flowcell') ; do
+while ( squeue -o "%j" | grep -q '^.collatefq.*$flowcell') ; do
    sleep 60
 done
 


### PR DESCRIPTION
Basically this was bash glob syntax vs. grep regex confusion.

This regex was incorrectly looking for `collatefq*`, which is `collatef` followed by any number of `q`s. Adjusted to properly look for `collatefq` followed by (any number of anything) before the flowcell string.