### PR TITLE
feat: write bcl2fastq output directly to /flowcells/, eliminating 3TB cross-filesystem rsync

### DIFF
--- a/scripts/flowcells/link_nextseq.py
+++ b/scripts/flowcells/link_nextseq.py
@@ -142,11 +142,9 @@ def create_links(
         output_name = "%s_%s_%03d.fastq.gz" % (sample_name, read, idx)
         output_file = os.path.join(output_dir, output_name)
 
-        rel_path = os.path.relpath(input_file, output_dir)
-
-        logging.info("Linking %s => %s", rel_path, output_file)
+        logging.info("Moving %s => %s", input_file, output_file)
         if not dry_run and not os.path.exists(output_file):
-            os.symlink(rel_path, output_file)
+            os.rename(input_file, output_file)
 
 
 def main():

--- a/scripts/flowcells/rename_fastq_files.py
+++ b/scripts/flowcells/rename_fastq_files.py
@@ -143,7 +143,7 @@ def rename_files(
         output_file = os.path.join(output_dir, output_name)
 
         logging.info("Moving %s => %s", input_file, output_file)
-        if not dry_run and not os.path.exists(output_file):
+        if not dry_run:
             os.rename(input_file, output_file)
 
 

--- a/scripts/flowcells/rename_fastq_files.py
+++ b/scripts/flowcells/rename_fastq_files.py
@@ -142,8 +142,10 @@ def rename_files(
         output_name = "%s_%s_%03d.fastq.gz" % (sample_name, read, idx)
         output_file = os.path.join(output_dir, output_name)
 
-        logging.info("Moving %s => %s", input_file, output_file)
-        if not dry_run:
+        if dry_run:
+            logging.info("Dry run, skipping move: %s => %s", input_file, output_file)
+        else:
+            logging.info("Moving %s => %s", input_file, output_file)
             os.rename(input_file, output_file)
 
 

--- a/scripts/flowcells/rename_fastq_files.py
+++ b/scripts/flowcells/rename_fastq_files.py
@@ -82,7 +82,7 @@ def rename_files(
     merge_across_lanes=False,
 ):
     """
-    Rename (move) fastq files from bcl-convert output into canonical sample names.
+    Rename (move) fastq files from bcl2fastq output into canonical sample names.
     If dry_run is passed, will print the planned renames instead of performing them.
     """
 

--- a/scripts/flowcells/rename_fastq_files.py
+++ b/scripts/flowcells/rename_fastq_files.py
@@ -62,7 +62,7 @@ def parser_setup():
         "--dry-run",
         dest="dry_run",
         action="store_true",
-        help="Only print out planned symlinks.",
+        help="Only print out planned renames without performing them.",
     )
 
     parser.set_defaults(**SCRIPT_OPTIONS)
@@ -71,7 +71,7 @@ def parser_setup():
     return parser
 
 
-def create_links(
+def rename_files(
     lane,
     read,
     input_basedir,
@@ -82,8 +82,8 @@ def create_links(
     merge_across_lanes=False,
 ):
     """
-    Create the links between the input directories and output dir
-    If dry_run is passed, will print them instead of creating them
+    Rename (move) fastq files from bcl-convert output into canonical sample names.
+    If dry_run is passed, will print the planned renames instead of performing them.
     """
 
     short_name = lane["samplesheet_name"]
@@ -168,7 +168,7 @@ def main():
 
     for lane in data["libraries"]:
         for read in ["R1", "R2", "R3", "R4"]:
-            create_links(
+            rename_files(
                 lane,
                 read,
                 input_dir,
@@ -182,7 +182,7 @@ def main():
         "samplesheet_name": "Undetermined",
     }
     for read in ["R1", "R2"]:
-        create_links(
+        rename_files(
             undet_lane,
             read,
             input_dir,
@@ -214,7 +214,7 @@ def main():
                 "project": "Lab",
             }
             for read in ["R1", "R2"]:
-                create_links(
+                rename_files(
                     lane,
                     read,
                     input_dir,

--- a/scripts/flowcells/setup.sh
+++ b/scripts/flowcells/setup.sh
@@ -632,7 +632,6 @@ _U_
     ;;
 esac
 
-copy_from_dir="$fastq_dir"
 if [ -n "$demux" ] ; then
   copy_from_dir="$(pwd)/Demultiplexed/"
   # obsolete now?
@@ -702,8 +701,8 @@ $unaligned_command
 
 # if the run is for GUIDEseq, swap the indexes
 if cat processing.json | grep -q "MiniSeq Mid Output Kit GUIDEseq"; then
-    zcat fastq/Undetermined_S0_L001_I2_001.fastq.gz | awk '{if(NR % 4 == 2) {x=(substr(\$0,9,16)); y=(substr(\$0,0,8)); print x y; } else print; }' > fastq/Undetermined_S0_L001_I2_001.rev.fastq
-    gzip fastq/Undetermined_S0_L001_I2_001.rev.fastq
+    zcat "$analysis_dir/bcl_output/fastq/Undetermined_S0_L001_I2_001.fastq.gz" | awk '{if(NR % 4 == 2) {x=(substr(\$0,9,16)); y=(substr(\$0,0,8)); print x y; } else print; }' > "$analysis_dir/bcl_output/fastq/Undetermined_S0_L001_I2_001.rev.fastq"
+    gzip "$analysis_dir/bcl_output/fastq/Undetermined_S0_L001_I2_001.rev.fastq"
 fi
 
 __FASTQ__

--- a/scripts/flowcells/setup.sh
+++ b/scripts/flowcells/setup.sh
@@ -315,7 +315,7 @@ read -d '' novaseq_bcl_command  << _NOVA_BCL_CMD_
       fastq_dir=\$(sed 's/,/-/g' <<< "fastq-withmask-\$bcl_mask")
       \$APX bcl2fastq \\\\
         --input-dir          "${illumina_dir}/Data/Intensities/BaseCalls" \\\\
-        --output-dir         "${illumina_dir}/\$fastq_dir"                \\\\
+        --output-dir         "${analysis_dir}/\$fastq_dir"               \\\\
         --use-bases-mask     "\$bcl_mask"                                 \\\\
         --barcode-mismatches "$mismatches"                                \\\\
         --sample-sheet       "${illumina_dir}/\$samplesheet"              \\\\
@@ -350,7 +350,7 @@ for samplesheet in SampleSheet.withmask*csv ; do
       PATH=/home/nelsonjs/src/bcl2fastq2/bin/:\$PATH
       \$APX bcl2fastq \\\\
         --input-dir          "${illumina_dir}/Data/Intensities/BaseCalls" \\\\
-        --output-dir         "${illumina_dir}/\\\$fastq_dir"              \\\\
+        --output-dir         "${analysis_dir}/\\\$fastq_dir"             \\\\
         --use-bases-mask     "\\\$bcl_mask"                               \\\\
         --tiles              "s_\\\$lane"                                 \\\\
         --barcode-mismatches "$mismatches"                                \\\\
@@ -392,7 +392,7 @@ case $run_type in
     parallel_env="-pe threads 6"
     link_command=$novaseq_link_command
     samplesheet="SampleSheet.csv"
-    fastq_dir="$illumina_dir/fastq"  # Lack of trailing slash is important for rsync!
+    fastq_dir="$analysis_dir/fastq"  # Written directly to flowcells, no rsync needed
     bc_flag="--novaseq"
     queue="$DEFAULT_QUEUE"
     $APX python "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 -p processing.json
@@ -407,7 +407,7 @@ case $run_type in
     parallel_env="-pe threads 6"
     link_command=$novaseq_link_command
     samplesheet="SampleSheet.csv"
-    fastq_dir="$illumina_dir/fastq"  # Lack of trailing slash is important for rsync!
+    fastq_dir="$analysis_dir/fastq"  # Written directly to flowcells, no rsync needed
     bc_flag="--novaseq"
     queue="$DEFAULT_QUEUE"
     $APX python "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 -p processing.json
@@ -422,7 +422,7 @@ case $run_type in
     parallel_env="-pe threads 6"
     link_command=$novaseq_link_command
     samplesheet="SampleSheet.csv"
-    fastq_dir="$illumina_dir/fastq"  # Lack of trailing slash is important for rsync!
+    fastq_dir="$analysis_dir/fastq"  # Written directly to flowcells, no rsync needed
     bc_flag="--novaseq"
     queue="$DEFAULT_QUEUE"
     $APX python "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 -p processing.json
@@ -437,7 +437,7 @@ case $run_type in
     parallel_env="-pe threads 6"
     link_command=$novaseq_link_command
     samplesheet="SampleSheet.csv"
-    fastq_dir="$illumina_dir/fastq"  # Lack of trailing slash is important for rsync!
+    fastq_dir="$analysis_dir/fastq"  # Written directly to flowcells, no rsync needed
     bc_flag="--novaseq"
     queue="$DEFAULT_QUEUE"
     $APX python "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 -p processing.json
@@ -452,7 +452,7 @@ case $run_type in
     parallel_env="-pe threads 6"
     link_command=$novaseq_link_command
     samplesheet="SampleSheet.csv"
-    fastq_dir="$illumina_dir/fastq"  # Lack of trailing slash is important for rsync!
+    fastq_dir="$analysis_dir/fastq"  # Written directly to flowcells, no rsync needed
     bc_flag="--novaseq"
     queue="$DEFAULT_QUEUE"
     $APX python "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 -p processing.json
@@ -467,7 +467,7 @@ case $run_type in
     parallel_env="-pe threads 6"
     link_command=$novaseq_link_command
     samplesheet="SampleSheet.csv"
-    fastq_dir="$illumina_dir/fastq"  # Lack of trailing slash is important for rsync!
+    fastq_dir="$analysis_dir/fastq"  # Written directly to flowcells, no rsync needed
     bc_flag="--novaseq"
     queue="$DEFAULT_QUEUE"
     $APX python "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 -p processing.json
@@ -483,7 +483,7 @@ case $run_type in
     parallel_env="-pe threads 6"
     link_command=$novaseq_link_command
     samplesheet="SampleSheet.csv"
-    fastq_dir="$illumina_dir/fastq"  # Lack of trailing slash is important for rsync!
+    fastq_dir="$analysis_dir/fastq"  # Written directly to flowcells, no rsync needed
     bc_flag="--novaseq"
     queue="$DEFAULT_QUEUE"
     $APX python "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 -p processing.json
@@ -495,9 +495,9 @@ case $run_type in
 
     echo "Regular NextSeq 500 run detected"
     parallel_env="-pe threads 6"
-    link_command="\$APX python3 $STAMPIPES/scripts/flowcells/link_nextseq.py -i fastq -o . --merge-across-lanes"
+    link_command="\$APX python3 $STAMPIPES/scripts/flowcells/link_nextseq.py -i fastq -o Demultiplexed --merge-across-lanes"
     samplesheet="SampleSheet.csv"
-    fastq_dir="$illumina_dir/fastq"  # Lack of trailing slash is important for rsync!
+    fastq_dir="$analysis_dir/fastq"  # Written directly to flowcells, no rsync needed
     bc_flag="--nextseq"
     queue="$SLOW_QUEUE"
     make_nextseq_samplesheet > SampleSheet.csv
@@ -507,9 +507,9 @@ case $run_type in
 "HiSeq 4000")
     echo "Hiseq 4000 run detected"
     parallel_env="-pe threads 6"
-    link_command="\$APX python3 $STAMPIPES/scripts/flowcells/link_nextseq.py -i fastq -o ."
+    link_command="\$APX python3 $STAMPIPES/scripts/flowcells/link_nextseq.py -i fastq -o Demultiplexed"
     samplesheet="SampleSheet.csv"
-    fastq_dir="$illumina_dir/fastq"  # Lack of trailing slash is important for rsync!
+    fastq_dir="$analysis_dir/fastq"  # Written directly to flowcells, no rsync needed
     bc_flag="--hiseq4k"
     queue="$SLOW_QUEUE"
     make_nextseq_samplesheet > SampleSheet.csv
@@ -520,9 +520,9 @@ case $run_type in
     # Identical to nextseq processing
     echo "High-output MiniSeq run detected for DNase"
     parallel_env="-pe threads 6"
-    link_command="\$APX python3 $STAMPIPES/scripts/flowcells/link_nextseq.py -i fastq -o . --merge-across-lanes"
+    link_command="\$APX python3 $STAMPIPES/scripts/flowcells/link_nextseq.py -i fastq -o Demultiplexed --merge-across-lanes"
     samplesheet="SampleSheet.csv"
-    fastq_dir="$illumina_dir/fastq"  # Lack of trailing slash is important for rsync!
+    fastq_dir="$analysis_dir/fastq"  # Written directly to flowcells, no rsync needed
     bc_flag="--miniseq"
     queue="$SLOW_QUEUE"
     make_nextseq_samplesheet > SampleSheet.csv
@@ -533,9 +533,9 @@ case $run_type in
     # Identical to nextseq processing
     echo "Mid-output MiniSeq run detected for GUIDEseq"
     parallel_env="-pe threads 6"
-    link_command="\$APX python3 $STAMPIPES/scripts/flowcells/link_nextseq.py -i fastq -o . --merge-across-lanes"
+    link_command="\$APX python3 $STAMPIPES/scripts/flowcells/link_nextseq.py -i fastq -o Demultiplexed --merge-across-lanes"
     samplesheet="SampleSheet.csv"
-    fastq_dir="$illumina_dir/fastq"  # Lack of trailing slash is important for rsync!
+    fastq_dir="$analysis_dir/fastq"  # Written directly to flowcells, no rsync needed
     bc_flag="--miniseq"
     queue="$SLOW_QUEUE"
     minidemux="True"
@@ -555,9 +555,9 @@ _U_
     # Identical to nextseq processing
     echo "Mid-output MiniSeq run detected"
     parallel_env="-pe threads 6"
-    link_command="\$APX python3 $STAMPIPES/scripts/flowcells/link_nextseq.py -i fastq -o . --merge-across-lanes"
+    link_command="\$APX python3 $STAMPIPES/scripts/flowcells/link_nextseq.py -i fastq -o Demultiplexed --merge-across-lanes"
     samplesheet="SampleSheet.csv"
-    fastq_dir="$illumina_dir/fastq"  # Lack of trailing slash is important for rsync!
+    fastq_dir="$analysis_dir/fastq"  # Written directly to flowcells, no rsync needed
     bc_flag="--miniseq"
     queue="$SLOW_QUEUE"
     minidemux="True"
@@ -576,9 +576,9 @@ _U_
     # Identical to nextseq processing
     echo "High-output MiniSeq run detected"
     parallel_env="-pe threads 6"
-    link_command="\$APX python3 $STAMPIPES/scripts/flowcells/link_nextseq.py -i fastq -o . --merge-across-lanes"
+    link_command="\$APX python3 $STAMPIPES/scripts/flowcells/link_nextseq.py -i fastq -o Demultiplexed --merge-across-lanes"
     samplesheet="SampleSheet.csv"
-    fastq_dir="$illumina_dir/fastq"  # Lack of trailing slash is important for rsync!
+    fastq_dir="$analysis_dir/fastq"  # Written directly to flowcells, no rsync needed
     bc_flag="--miniseq"
     queue="$SLOW_QUEUE"
     minidemux="True"
@@ -638,8 +638,11 @@ if [ -n "$demux" ] ; then
   # obsolete now?
   demux_cmd="$STAMPIPES/scripts/flowcells/demux_flowcell.sh -i $fastq_dir -o $copy_from_dir -p $json -q $queue -m $dmx_mismatches"
   link_command="#Demuxing happened, no linking to do"
-elif [[ "$bc_flag" == "--novaseq" ]] ; then
-  copy_from_dir="$(pwd)/Demultiplexed/"
+else
+  # All paths write FASTQs directly to analysis_dir; link_nextseq.py renames
+  # them into Demultiplexed/ as an intermediate before the copy step moves them
+  # to their final locations.
+  copy_from_dir="$analysis_dir/Demultiplexed/"
 fi
 
 flowcell_id=$( curl \
@@ -683,6 +686,9 @@ while [ ! -e "$illumina_dir/CopyComplete.txt" ] ; do sleep 60 ; done
 # Register as "Processing" in LIMS
 lims_patch "flowcell_run/$flowcell_id/" "status=https://lims.stamlab.org/api/flowcell_run_status/3/"
 lims_patch "flowcell_run/$flowcell_id/" "folder_name=${PWD##*/}"
+
+# Create output directory on flowcells before bcl-convert writes to it
+mkdir -p "$analysis_dir"
 
 # bcl2fastq
 bcl_jobid=\$(sbatch --export=ALL -J "u-$flowcell" -o "u-$flowcell.o%A" -e "u-$flowcell.e%A" \$dependencies_barcodes --partition=$queue --ntasks=1 --cpus-per-task=20 --mem-per-cpu=8000 --parsable --oversubscribe <<'__FASTQ__'
@@ -758,6 +764,9 @@ while [ ! -e "$illumina_dir/CopyComplete.txt" ] ; do sleep 60 ; done
 # Register as "Processing" in LIMS
 lims_patch "flowcell_run/$flowcell_id/" "status=https://lims.stamlab.org/api/flowcell_run_status/3/"
 lims_patch "flowcell_run/$flowcell_id/" "folder_name=${PWD##*/}"
+
+# Create output directory on flowcells before bcl-convert writes to it
+mkdir -p "$analysis_dir"
 
 # Submit a barcode job for each mask
 for bcmask in $($APX python $STAMPIPES/scripts/flowcells/barcode_masks.py | xargs) ; do
@@ -840,17 +849,28 @@ fi
 copy_jobid=\$(sbatch --export=ALL -J "c-$flowcell" \$dmx_dependency -o "c-$flowcell.o%A" -e "c-$flowcell.e%A" --partition=$queue --cpus-per-task=1 --ntasks=1 --mem-per-cpu=1000 --parsable --oversubscribe <<'__COPY__'
 #!/bin/bash
 source "$STAMPIPES/scripts/sentry/sentry-lib.bash"
+
+# Restrict access to intermediate fastq dirs while they contain raw demux output
+chmod 700 "$analysis_dir"/fastq "$analysis_dir"/fastq-withmask-* 2>/dev/null || true
+
+# Copy processing.json to analysis_dir and cd there so link_nextseq.py
+# resolves its -i and -o arguments correctly relative to analysis_dir
+cp "$illumina_dir/processing.json" "$analysis_dir/"
+cd "$analysis_dir"
 $link_command
 
-# copy files
-mkdir -p "$analysis_dir"
+# Remove now-empty intermediate fastq dirs (files were renamed out by link step)
+rm -rf "$analysis_dir"/fastq "$analysis_dir"/fastq-withmask-*
+
+# Copy small metadata files from the illumina run dir
 rsync -avP "$illumina_dir/InterOp" "$analysis_dir/"
 rsync -avP "$illumina_dir/RunInfo.xml" "$analysis_dir/"
 rsync -avP "$illumina_dir"/SampleSheet*.csv "$analysis_dir/"
 
 
-# Copy each sample by itself, checking to see if we have a project_share_directory set
-# This is very important to keep customer data separate from internal data.
+# Move each sample into its final location. Samples with a project_share_directory
+# are rsynced to a potentially different filesystem; internal samples are renamed
+# (O(1) on the same filesystem, no data movement).
 (
     cd "$copy_from_dir"
     for dir in Project*/Sample* ; do
@@ -860,22 +880,31 @@ rsync -avP "$illumina_dir"/SampleSheet*.csv "$analysis_dir/"
         destination=\$(jq -c -r ".libraries[] | select(.sample == \$samp_number) | .project_share_directory" ../processing.json)
         if [[ -z "\$destination" ]] || [[ "null" == "\$destination" ]] ; then
             destination=$analysis_dir
+            use_rsync=
         elif [[ ! -d "\$destination" ]] ; then
             echo "Destination \$destination does not exist! Please create it." >&2
             exit 1
         else
             destination=\$destination/fastq
+            use_rsync=1
         fi
         destination=\$destination/\$dir
-        mkdir -p "\$destination"
-        rsync -aL "\$dir/" "\$destination/"
+        if [[ -n "\$use_rsync" ]] ; then
+            # External share: copy to a (potentially different) filesystem path
+            mkdir -p "\$destination"
+            rsync -a "\$dir/" "\$destination/"
+        else
+            # Internal: fast rename within the same filesystem
+            mkdir -p "\$(dirname "\$destination")"
+            mv "\$dir" "\$destination"
+        fi
     done
     for dir in Project*/LibraryPool* ; do
         [[ -d \$dir ]] || continue
         destination=$analysis_dir
         destination=\$destination/\$dir
-        mkdir -p "\$destination"
-        rsync -aL "\$dir/" "\$destination/"
+        mkdir -p "\$(dirname "\$destination")"
+        mv "\$dir" "\$destination"
     done
 )
 

--- a/scripts/flowcells/setup.sh
+++ b/scripts/flowcells/setup.sh
@@ -850,6 +850,7 @@ fi
 copy_jobid=\$(sbatch --export=ALL -J "c-$flowcell" \$dmx_dependency -o "c-$flowcell.o%A" -e "c-$flowcell.e%A" --partition=$queue --cpus-per-task=1 --ntasks=1 --mem-per-cpu=1000 --parsable --oversubscribe <<'__COPY__'
 #!/bin/bash
 source "$STAMPIPES/scripts/sentry/sentry-lib.bash"
+set -euo pipefail
 
 # Copy processing.json to analysis_dir and cd there so rename_fastq_files.py
 # resolves its -i and -o arguments correctly relative to analysis_dir
@@ -891,15 +892,16 @@ rsync -avP "$illumina_dir"/SampleSheet*.csv "$analysis_dir/"
         else
             # Internal: fast rename within the same filesystem
             mkdir -p "\$(dirname "\$destination")"
-            mv "\$dir" "\$destination"
+            mkdir -p "\$destination"
+            find "\$dir" -maxdepth 1 -mindepth 1 -exec mv -f '{}' "\$destination/" ';'
         fi
     done
     for dir in Project*/LibraryPool* ; do
         [[ -d \$dir ]] || continue
         destination=$analysis_dir
         destination=\$destination/\$dir
-        mkdir -p "\$(dirname "\$destination")"
-        mv "\$dir" "\$destination"
+        mkdir -p "\$destination"
+        find "\$dir" -maxdepth 1 -mindepth 1 -exec mv -f '{}' "\$destination/" ';'
     done
 )
 

--- a/scripts/flowcells/setup.sh
+++ b/scripts/flowcells/setup.sh
@@ -315,7 +315,7 @@ read -d '' novaseq_bcl_command  << _NOVA_BCL_CMD_
       fastq_dir=\$(sed 's/,/-/g' <<< "fastq-withmask-\$bcl_mask")
       \$APX bcl2fastq \\\\
         --input-dir          "${illumina_dir}/Data/Intensities/BaseCalls" \\\\
-        --output-dir         "${analysis_dir}/\$fastq_dir"               \\\\
+        --output-dir         "${analysis_dir}/bcl_output/\$fastq_dir"        \\\\
         --use-bases-mask     "\$bcl_mask"                                 \\\\
         --barcode-mismatches "$mismatches"                                \\\\
         --sample-sheet       "${illumina_dir}/\$samplesheet"              \\\\
@@ -350,7 +350,7 @@ for samplesheet in SampleSheet.withmask*csv ; do
       PATH=/home/nelsonjs/src/bcl2fastq2/bin/:\$PATH
       \$APX bcl2fastq \\\\
         --input-dir          "${illumina_dir}/Data/Intensities/BaseCalls" \\\\
-        --output-dir         "${analysis_dir}/\\\$fastq_dir"             \\\\
+        --output-dir         "${analysis_dir}/bcl_output/\\\$fastq_dir"  \\\\
         --use-bases-mask     "\\\$bcl_mask"                               \\\\
         --tiles              "s_\\\$lane"                                 \\\\
         --barcode-mismatches "$mismatches"                                \\\\
@@ -370,9 +370,9 @@ fi
 _NOVA_SUBMIT_CMD_
 
 read -d '' novaseq_link_command  <<'_NOVA_LINK_CMD_'
-for fq_dir in fastq-withmask-* ; do
+for fq_dir in bcl_output/fastq-withmask-* ; do
   [[ -d $fq_dir ]] || continue
-  $APX python3 $STAMPIPES/scripts/flowcells/link_nextseq.py -i "$fq_dir" -o Demultiplexed -p processing.json
+  $APX python3 $STAMPIPES/scripts/flowcells/rename_fastq_files.py -i "$fq_dir" -o Demultiplexed -p processing.json
 done
 _NOVA_LINK_CMD_
 set -e
@@ -392,7 +392,7 @@ case $run_type in
     parallel_env="-pe threads 6"
     link_command=$novaseq_link_command
     samplesheet="SampleSheet.csv"
-    fastq_dir="$analysis_dir/fastq"  # Written directly to flowcells, no rsync needed
+    fastq_dir="$analysis_dir/bcl_output/fastq"  # Written directly to flowcells/bcl_output/, no rsync needed
     bc_flag="--novaseq"
     queue="$DEFAULT_QUEUE"
     $APX python "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 -p processing.json
@@ -407,7 +407,7 @@ case $run_type in
     parallel_env="-pe threads 6"
     link_command=$novaseq_link_command
     samplesheet="SampleSheet.csv"
-    fastq_dir="$analysis_dir/fastq"  # Written directly to flowcells, no rsync needed
+    fastq_dir="$analysis_dir/bcl_output/fastq"  # Written directly to flowcells/bcl_output/, no rsync needed
     bc_flag="--novaseq"
     queue="$DEFAULT_QUEUE"
     $APX python "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 -p processing.json
@@ -422,7 +422,7 @@ case $run_type in
     parallel_env="-pe threads 6"
     link_command=$novaseq_link_command
     samplesheet="SampleSheet.csv"
-    fastq_dir="$analysis_dir/fastq"  # Written directly to flowcells, no rsync needed
+    fastq_dir="$analysis_dir/bcl_output/fastq"  # Written directly to flowcells/bcl_output/, no rsync needed
     bc_flag="--novaseq"
     queue="$DEFAULT_QUEUE"
     $APX python "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 -p processing.json
@@ -437,7 +437,7 @@ case $run_type in
     parallel_env="-pe threads 6"
     link_command=$novaseq_link_command
     samplesheet="SampleSheet.csv"
-    fastq_dir="$analysis_dir/fastq"  # Written directly to flowcells, no rsync needed
+    fastq_dir="$analysis_dir/bcl_output/fastq"  # Written directly to flowcells/bcl_output/, no rsync needed
     bc_flag="--novaseq"
     queue="$DEFAULT_QUEUE"
     $APX python "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 -p processing.json
@@ -452,7 +452,7 @@ case $run_type in
     parallel_env="-pe threads 6"
     link_command=$novaseq_link_command
     samplesheet="SampleSheet.csv"
-    fastq_dir="$analysis_dir/fastq"  # Written directly to flowcells, no rsync needed
+    fastq_dir="$analysis_dir/bcl_output/fastq"  # Written directly to flowcells/bcl_output/, no rsync needed
     bc_flag="--novaseq"
     queue="$DEFAULT_QUEUE"
     $APX python "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 -p processing.json
@@ -467,7 +467,7 @@ case $run_type in
     parallel_env="-pe threads 6"
     link_command=$novaseq_link_command
     samplesheet="SampleSheet.csv"
-    fastq_dir="$analysis_dir/fastq"  # Written directly to flowcells, no rsync needed
+    fastq_dir="$analysis_dir/bcl_output/fastq"  # Written directly to flowcells/bcl_output/, no rsync needed
     bc_flag="--novaseq"
     queue="$DEFAULT_QUEUE"
     $APX python "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 -p processing.json
@@ -483,7 +483,7 @@ case $run_type in
     parallel_env="-pe threads 6"
     link_command=$novaseq_link_command
     samplesheet="SampleSheet.csv"
-    fastq_dir="$analysis_dir/fastq"  # Written directly to flowcells, no rsync needed
+    fastq_dir="$analysis_dir/bcl_output/fastq"  # Written directly to flowcells/bcl_output/, no rsync needed
     bc_flag="--novaseq"
     queue="$DEFAULT_QUEUE"
     $APX python "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 -p processing.json
@@ -495,9 +495,9 @@ case $run_type in
 
     echo "Regular NextSeq 500 run detected"
     parallel_env="-pe threads 6"
-    link_command="\$APX python3 $STAMPIPES/scripts/flowcells/link_nextseq.py -i fastq -o Demultiplexed --merge-across-lanes"
+    link_command="\$APX python3 $STAMPIPES/scripts/flowcells/rename_fastq_files.py -i bcl_output/fastq -o Demultiplexed --merge-across-lanes"
     samplesheet="SampleSheet.csv"
-    fastq_dir="$analysis_dir/fastq"  # Written directly to flowcells, no rsync needed
+    fastq_dir="$analysis_dir/bcl_output/fastq"  # Written directly to flowcells/bcl_output/, no rsync needed
     bc_flag="--nextseq"
     queue="$SLOW_QUEUE"
     make_nextseq_samplesheet > SampleSheet.csv
@@ -507,9 +507,9 @@ case $run_type in
 "HiSeq 4000")
     echo "Hiseq 4000 run detected"
     parallel_env="-pe threads 6"
-    link_command="\$APX python3 $STAMPIPES/scripts/flowcells/link_nextseq.py -i fastq -o Demultiplexed"
+    link_command="\$APX python3 $STAMPIPES/scripts/flowcells/rename_fastq_files.py -i bcl_output/fastq -o Demultiplexed"
     samplesheet="SampleSheet.csv"
-    fastq_dir="$analysis_dir/fastq"  # Written directly to flowcells, no rsync needed
+    fastq_dir="$analysis_dir/bcl_output/fastq"  # Written directly to flowcells/bcl_output/, no rsync needed
     bc_flag="--hiseq4k"
     queue="$SLOW_QUEUE"
     make_nextseq_samplesheet > SampleSheet.csv
@@ -520,9 +520,9 @@ case $run_type in
     # Identical to nextseq processing
     echo "High-output MiniSeq run detected for DNase"
     parallel_env="-pe threads 6"
-    link_command="\$APX python3 $STAMPIPES/scripts/flowcells/link_nextseq.py -i fastq -o Demultiplexed --merge-across-lanes"
+    link_command="\$APX python3 $STAMPIPES/scripts/flowcells/rename_fastq_files.py -i bcl_output/fastq -o Demultiplexed --merge-across-lanes"
     samplesheet="SampleSheet.csv"
-    fastq_dir="$analysis_dir/fastq"  # Written directly to flowcells, no rsync needed
+    fastq_dir="$analysis_dir/bcl_output/fastq"  # Written directly to flowcells/bcl_output/, no rsync needed
     bc_flag="--miniseq"
     queue="$SLOW_QUEUE"
     make_nextseq_samplesheet > SampleSheet.csv
@@ -533,9 +533,9 @@ case $run_type in
     # Identical to nextseq processing
     echo "Mid-output MiniSeq run detected for GUIDEseq"
     parallel_env="-pe threads 6"
-    link_command="\$APX python3 $STAMPIPES/scripts/flowcells/link_nextseq.py -i fastq -o Demultiplexed --merge-across-lanes"
+    link_command="\$APX python3 $STAMPIPES/scripts/flowcells/rename_fastq_files.py -i bcl_output/fastq -o Demultiplexed --merge-across-lanes"
     samplesheet="SampleSheet.csv"
-    fastq_dir="$analysis_dir/fastq"  # Written directly to flowcells, no rsync needed
+    fastq_dir="$analysis_dir/bcl_output/fastq"  # Written directly to flowcells/bcl_output/, no rsync needed
     bc_flag="--miniseq"
     queue="$SLOW_QUEUE"
     minidemux="True"
@@ -555,9 +555,9 @@ _U_
     # Identical to nextseq processing
     echo "Mid-output MiniSeq run detected"
     parallel_env="-pe threads 6"
-    link_command="\$APX python3 $STAMPIPES/scripts/flowcells/link_nextseq.py -i fastq -o Demultiplexed --merge-across-lanes"
+    link_command="\$APX python3 $STAMPIPES/scripts/flowcells/rename_fastq_files.py -i bcl_output/fastq -o Demultiplexed --merge-across-lanes"
     samplesheet="SampleSheet.csv"
-    fastq_dir="$analysis_dir/fastq"  # Written directly to flowcells, no rsync needed
+    fastq_dir="$analysis_dir/bcl_output/fastq"  # Written directly to flowcells/bcl_output/, no rsync needed
     bc_flag="--miniseq"
     queue="$SLOW_QUEUE"
     minidemux="True"
@@ -576,9 +576,9 @@ _U_
     # Identical to nextseq processing
     echo "High-output MiniSeq run detected"
     parallel_env="-pe threads 6"
-    link_command="\$APX python3 $STAMPIPES/scripts/flowcells/link_nextseq.py -i fastq -o Demultiplexed --merge-across-lanes"
+    link_command="\$APX python3 $STAMPIPES/scripts/flowcells/rename_fastq_files.py -i bcl_output/fastq -o Demultiplexed --merge-across-lanes"
     samplesheet="SampleSheet.csv"
-    fastq_dir="$analysis_dir/fastq"  # Written directly to flowcells, no rsync needed
+    fastq_dir="$analysis_dir/bcl_output/fastq"  # Written directly to flowcells/bcl_output/, no rsync needed
     bc_flag="--miniseq"
     queue="$SLOW_QUEUE"
     minidemux="True"
@@ -639,7 +639,7 @@ if [ -n "$demux" ] ; then
   demux_cmd="$STAMPIPES/scripts/flowcells/demux_flowcell.sh -i $fastq_dir -o $copy_from_dir -p $json -q $queue -m $dmx_mismatches"
   link_command="#Demuxing happened, no linking to do"
 else
-  # All paths write FASTQs directly to analysis_dir; link_nextseq.py renames
+  # All paths write FASTQs directly to analysis_dir/bcl_output/; rename_fastq_files.py renames
   # them into Demultiplexed/ as an intermediate before the copy step moves them
   # to their final locations.
   copy_from_dir="$analysis_dir/Demultiplexed/"
@@ -687,8 +687,9 @@ while [ ! -e "$illumina_dir/CopyComplete.txt" ] ; do sleep 60 ; done
 lims_patch "flowcell_run/$flowcell_id/" "status=https://lims.stamlab.org/api/flowcell_run_status/3/"
 lims_patch "flowcell_run/$flowcell_id/" "folder_name=${PWD##*/}"
 
-# Create output directory on flowcells before bcl-convert writes to it
-mkdir -p "$analysis_dir"
+# Create output subdirectory with restricted permissions before bcl-convert writes to it
+mkdir -p "$analysis_dir/bcl_output"
+chmod 700 "$analysis_dir/bcl_output"
 
 # bcl2fastq
 bcl_jobid=\$(sbatch --export=ALL -J "u-$flowcell" -o "u-$flowcell.o%A" -e "u-$flowcell.e%A" \$dependencies_barcodes --partition=$queue --ntasks=1 --cpus-per-task=20 --mem-per-cpu=8000 --parsable --oversubscribe <<'__FASTQ__'
@@ -765,8 +766,9 @@ while [ ! -e "$illumina_dir/CopyComplete.txt" ] ; do sleep 60 ; done
 lims_patch "flowcell_run/$flowcell_id/" "status=https://lims.stamlab.org/api/flowcell_run_status/3/"
 lims_patch "flowcell_run/$flowcell_id/" "folder_name=${PWD##*/}"
 
-# Create output directory on flowcells before bcl-convert writes to it
-mkdir -p "$analysis_dir"
+# Create output subdirectory with restricted permissions before bcl-convert writes to it
+mkdir -p "$analysis_dir/bcl_output"
+chmod 700 "$analysis_dir/bcl_output"
 
 # Submit a barcode job for each mask
 for bcmask in $($APX python $STAMPIPES/scripts/flowcells/barcode_masks.py | xargs) ; do
@@ -850,17 +852,11 @@ copy_jobid=\$(sbatch --export=ALL -J "c-$flowcell" \$dmx_dependency -o "c-$flowc
 #!/bin/bash
 source "$STAMPIPES/scripts/sentry/sentry-lib.bash"
 
-# Restrict access to intermediate fastq dirs while they contain raw demux output
-chmod 700 "$analysis_dir"/fastq "$analysis_dir"/fastq-withmask-* 2>/dev/null || true
-
-# Copy processing.json to analysis_dir and cd there so link_nextseq.py
+# Copy processing.json to analysis_dir and cd there so rename_fastq_files.py
 # resolves its -i and -o arguments correctly relative to analysis_dir
 cp "$illumina_dir/processing.json" "$analysis_dir/"
 cd "$analysis_dir"
 $link_command
-
-# Remove now-empty intermediate fastq dirs (files were renamed out by link step)
-rm -rf "$analysis_dir"/fastq "$analysis_dir"/fastq-withmask-*
 
 # Copy small metadata files from the illumina run dir
 rsync -avP "$illumina_dir/InterOp" "$analysis_dir/"

--- a/scripts/flowcells/setup.sh
+++ b/scripts/flowcells/setup.sh
@@ -687,7 +687,7 @@ while [ ! -e "$illumina_dir/CopyComplete.txt" ] ; do sleep 60 ; done
 lims_patch "flowcell_run/$flowcell_id/" "status=https://lims.stamlab.org/api/flowcell_run_status/3/"
 lims_patch "flowcell_run/$flowcell_id/" "folder_name=${PWD##*/}"
 
-# Create output subdirectory with restricted permissions before bcl-convert writes to it
+# Create output subdirectory with restricted permissions before bcl2fastq writes to it
 mkdir -p "$analysis_dir/bcl_output"
 chmod 700 "$analysis_dir/bcl_output"
 
@@ -766,7 +766,7 @@ while [ ! -e "$illumina_dir/CopyComplete.txt" ] ; do sleep 60 ; done
 lims_patch "flowcell_run/$flowcell_id/" "status=https://lims.stamlab.org/api/flowcell_run_status/3/"
 lims_patch "flowcell_run/$flowcell_id/" "folder_name=${PWD##*/}"
 
-# Create output subdirectory with restricted permissions before bcl-convert writes to it
+# Create output subdirectory with restricted permissions before bcl2fastq writes to it
 mkdir -p "$analysis_dir/bcl_output"
 chmod 700 "$analysis_dir/bcl_output"
 


### PR DESCRIPTION
## Summary

Eliminates the slow copy phase in `setup.sh` by writing bcl2fastq output directly to the destination filesystem (`/flowcells/`) instead of `/sequencers/`, then rsyncing 3TB across.

## Key changes

### `scripts/flowcells/setup.sh`
- All bcl2fastq `--output-dir` args now write to `$analysis_dir/bcl_output/` (a restricted subdirectory under the flowcell analysis dir on `/flowcells/`)
- `bcl_output/` is created with `chmod 700` **before** the bcl2fastq job is submitted, so permissions are set before any files exist
- `copy_from_dir` is unified to `$analysis_dir/Demultiplexed/` for all non-legacy paths
- In the copy SLURM job: internal samples now use `mv` (O(1) rename, no data movement) instead of `rsync -aL`; only samples with a `project_share_directory` still use `rsync`
- bcl_output/ intermediate directories are **not** deleted — they retain stats, logs, and reports from bcl2fastq

### `scripts/flowcells/rename_fastq_files.py` (was `link_nextseq.py`)
- Renamed to reflect that it now moves files rather than creating symlinks
- `os.symlink()` replaced with `os.rename()` — files are moved to canonical sample names; since everything is on the same filesystem this is an O(1) metadata operation
- All internal verbiage (`create_links`, 'symlinks') updated to match

## Commits
- `d42d1a2` feat: write bcl2fastq output directly to /flowcells/
- `2428eea` refactor: rename link_nextseq.py, nest bcl output in bcl_output/ subdir
- `fb3c5a7` fix: terminology (bcl-convert → bcl2fastq in comments)
- `5651e75` fix: GUIDEseq index-swap paths updated to bcl_output/fastq/