### PR TITLE
Feat/bcl convert

### DIFF
--- a/scripts/flowcells/make_samplesheets.py
+++ b/scripts/flowcells/make_samplesheets.py
@@ -1,4 +1,14 @@
 #!/usr/bin/env python3
+"""
+Generate bcl-convert compatible sample sheets from processing.json
+
+This script creates sample sheets with the bcl-convert v2 format, including:
+- OverrideCycles in [Settings] section (replaces bcl2fastq's --use-bases-mask)
+- BarcodeMismatchesIndex1/2 in [Settings] section
+- Proper [Data] section with Lane, Sample_ID, index, index2 columns
+
+Usage: $0 -p processing.json [--mismatches 1,1] [--reverse_barcode1] [--reverse_barcode2] [--filename SampleSheet.withmask.{mask}.csv]
+"""
 
 import argparse
 import datetime
@@ -7,23 +17,161 @@ import re
 import sys
 import textwrap
 from collections import defaultdict
-
-# requires BioPython which seems to be in our environment
-# but only to reverse complement which we could figure out
-# another way to do
-
-# Usage: $0 -p processing.json
+from dataclasses import dataclass, field
 
 SCRIPT_OPTIONS = {
     "processing": "processing.json",
     "reverse_barcode1": False,
     "reverse_barcode2": False,
     "filename": "SampleSheet.withmask.{mask}.csv",
+    "mismatches": "1,1",
 }
 
 
+@dataclass
+class BasesMask:
+    """
+    Represents a bases mask / cycle override for Illumina sequencing.
+
+    A mask consists of multiple "reads" (segments), each containing pieces
+    that describe how to handle bases:
+    - 'y' = use for sequencing read
+    - 'i' = use for index/barcode
+    - 'n' = skip/ignore
+    - 'u' = use for UMI
+
+    Examples:
+        "y151,i8,i8,y151" - paired-end 151bp with dual 8bp indexes
+        "y76,i8,y76" - paired-end 76bp with single 8bp index
+    """
+
+    # Each read is a list of (letter, count) tuples
+    # e.g., [[('y', 151)], [('i', 8)], [('i', 8)], [('y', 151)]]
+    reads: list[list[tuple[str, int]]] = field(default_factory=list)
+
+    @classmethod
+    def parse(cls, mask_str: str) -> "BasesMask":
+        """Parse a bases mask string into a BasesMask object."""
+        reads = []
+        str_parts = mask_str.split(",")
+        regex = r"(?P<letter>[yniu])(?P<num>[0-9]*)"
+        for part in str_parts:
+            pieces = []
+            for match in re.finditer(regex, part, flags=re.I):
+                letter = match.group("letter").lower()
+                num_str = match.group("num")
+                num = 1 if len(num_str) == 0 else int(num_str)
+                if pieces and pieces[-1][0] == letter:
+                    # Collapse same-letter adjacent pieces
+                    pieces[-1] = (pieces[-1][0], pieces[-1][1] + num)
+                else:
+                    pieces.append((letter, num))
+            reads.append(pieces)
+        return cls(reads=reads)
+
+    def __str__(self) -> str:
+        """Convert to bcl2fastq-style mask string (comma-separated, lowercase)."""
+
+        def format_piece(letter: str, num: int) -> str:
+            if num == 0:
+                return ""
+            elif num == 1:
+                return letter
+            return f"{letter}{num}"
+
+        return ",".join(
+            "".join(format_piece(*piece) for piece in read) for read in self.reads
+        )
+
+    def to_override_cycles(self) -> str:
+        """
+        Convert to bcl-convert OverrideCycles format.
+
+        bcl-convert uses semicolons between reads and uppercase letters:
+        - Y = use bases for read
+        - I = use bases for index
+        - U = use bases for UMI
+        - N = skip bases
+
+        Example: Y151;I8;I8;Y151
+        """
+
+        def format_piece(letter: str, num: int) -> str:
+            if num == 0:
+                return ""
+            upper = letter.upper()
+            if num == 1:
+                return upper
+            return f"{upper}{num}"
+
+        return ";".join(
+            "".join(format_piece(*piece) for piece in read) for read in self.reads
+        )
+
+    @property
+    def num_index_reads(self) -> int:
+        """Count the number of index reads in the mask."""
+        return sum(1 for read in self.reads if any(piece[0] == "i" for piece in read))
+
+    @property
+    def index_lengths(self) -> tuple[int, int]:
+        """
+        Return the lengths of index1 and index2.
+        Returns (0, 0) if no indexes, (len1, 0) if single index.
+        """
+        len1, len2 = 0, 0
+        index_num = 0
+        for read in self.reads:
+            is_index = any(piece[0] == "i" for piece in read)
+            if is_index:
+                read_len = sum(piece[1] for piece in read)
+                index_num += 1
+                if index_num == 1:
+                    len1 = read_len
+                elif index_num == 2:
+                    len2 = read_len
+        return (len1, len2)
+
+    def adjust_for_barcode_lengths(self, bc1_len: int, bc2_len: int) -> "BasesMask":
+        """
+        Create a new BasesMask adjusted for actual barcode lengths.
+
+        If barcodes are shorter than the index read, pads with 'n'.
+        If barcodes are longer than the index read, truncates.
+        """
+        new_reads = []
+        index_num = 0
+
+        for read in self.reads:
+            read_len = sum(piece[1] for piece in read)
+            is_index = any(piece[0] == "i" for piece in read)
+
+            if is_index:
+                if any(piece[0] == "y" for piece in read):
+                    raise ValueError(
+                        f"Mixed read/index in barcode mask '{self}', "
+                        "don't know how to deal with this"
+                    )
+
+                index_num += 1
+                bc_len = bc1_len if index_num == 1 else bc2_len
+
+                if bc_len >= read_len:
+                    # Barcode fills or exceeds the read
+                    new_reads.append([("i", read_len)])
+                else:
+                    # Barcode is shorter, pad with 'n'
+                    new_reads.append([("i", bc_len), ("n", read_len - bc_len)])
+            else:
+                new_reads.append(read)
+
+        return BasesMask(reads=new_reads)
+
+
 def parser_setup():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        description="Generate bcl-convert compatible sample sheets from processing.json"
+    )
     parser.add_argument(
         "-p",
         "--processing",
@@ -46,13 +194,17 @@ def parser_setup():
         "--filename",
         help="The template to use for filename, with the {mask} formatting",
     )
+    parser.add_argument(
+        "--mismatches",
+        help="Barcode mismatches allowed, as 'index1,index2' (default: 1,1)",
+    )
     parser.set_defaults(**SCRIPT_OPTIONS)
     return parser
 
 
 def get_barcode_assignments(
     data: dict, reverse_barcode1: bool, reverse_barcode2: bool
-) -> "[dict]":
+) -> "list[dict]":
     assignments = []
 
     for libdata in data["libraries"]:
@@ -82,7 +234,33 @@ def get_barcode_assignments(
     return assignments
 
 
-def make_samplesheet_header(name: str, date: str) -> str:
+def make_samplesheet_header(
+    name: str, date: str, mask: BasesMask, mismatches: str
+) -> str:
+    """
+    Generate bcl-convert v2 format sample sheet header.
+
+    Args:
+        name: Project/investigator name
+        date: Date string
+        mask: BasesMask object for the override cycles
+        mismatches: Comma-separated mismatches for index1,index2 (e.g., "1,1")
+    """
+    mismatch_parts = mismatches.split(",")
+    mismatch1 = mismatch_parts[0] if len(mismatch_parts) > 0 else "1"
+    mismatch2 = mismatch_parts[1] if len(mismatch_parts) > 1 else mismatch1
+
+    # Build mismatch settings - only include Index2 if there are 2 index reads
+    num_indexes = mask.num_index_reads
+    if num_indexes >= 2:
+        mismatch_settings = (
+            f"BarcodeMismatchesIndex1,{mismatch1}\nBarcodeMismatchesIndex2,{mismatch2}"
+        )
+    elif num_indexes == 1:
+        mismatch_settings = f"BarcodeMismatchesIndex1,{mismatch1}"
+    else:
+        mismatch_settings = ""
+
     template = textwrap.dedent("""\
     [Header]
     Investigator Name,{name}
@@ -92,14 +270,21 @@ def make_samplesheet_header(name: str, date: str) -> str:
     Workflow,GenerateFASTQ
 
     [Settings]
+    OverrideCycles,{override_cycles}
+    {mismatch_settings}
 
     [Data]
-    Lane,SampleID,SampleName,index,index2
+    Lane,Sample_ID,index,index2
     """)
-    return template.format(date=date, name=name)
+    return template.format(
+        date=date,
+        name=name,
+        override_cycles=mask.to_override_cycles(),
+        mismatch_settings=mismatch_settings,
+    )
 
 
-def group_assignments(assignments: "[dict]") -> "[[dict]]":
+def group_assignments(assignments: "list[dict]") -> "dict[tuple[int, int], list[dict]]":
     """Groups the barcode assignments by length"""
     barcode_length_combinations = defaultdict(list)
 
@@ -115,130 +300,49 @@ def group_assignments(assignments: "[dict]") -> "[[dict]]":
     return barcode_length_combinations
 
 
-def parse_mask(mask: str) -> "[[(str, int)]]":
-    parts = []
-    str_parts = mask.split(",")
-    regex = r"(?P<letter>[yni])(?P<num>[0-9]*)"
-    for part in str_parts:
-        pieces = []
-        for match in re.finditer(regex, part, flags=re.I):
-            letter = match.group("letter").lower()
-            num_str = match.group("num")
-            num = 1 if len(num_str) == 0 else int(num_str)
-            if pieces and pieces[-1][0] == letter:
-                # Collapse same-letter adjacent pieces
-                pieces[-1][1] += num
-            else:
-                pieces.append((letter, num))
-        parts.append(pieces)
-    return parts
+def write_samplesheets(
+    name: str,
+    filename_template: str,
+    date: str,
+    root_mask: str,
+    assignments: list[dict],
+    mismatches: str = "1,1",
+) -> None:
+    """Write out the sample sheets in bcl-convert v2 format."""
+    mask = BasesMask.parse(root_mask)
+    max_bclen1, max_bclen2 = mask.index_lengths
 
-
-def mask_to_str(mask: "[[(str, int)]]") -> str:
-    """Convert a mask in parts back into a string"""
-
-    def format_piece(letter, num):
-        if num == 0:
-            return ""
-        elif num == 1:
-            return letter
-        else:
-            return letter + str(num)
-
-    return ",".join(
-        ["".join([format_piece(*piece) for piece in part]) for part in mask]
-    )
-
-
-def adjust_mask_for_lengths(mask_parts, len1, len2):
-    """
-    Takes in a barcode-mask (in parts) and the barcode length, and adjusts the
-    values of 'i' to match.
-    """
-    new_mask = []
-    index_reads_seen = 0
-    for read in mask_parts:
-        read_len = sum(piece[1] for piece in read)
-        is_index_read = any(piece[0] == "i" for piece in read)
-        if is_index_read:
-            if any(piece[0] == "y" for piece in read):
-                raise Exception(
-                    "Mixed read/index in barcode mask '{}', don't know how to deal with this".format(
-                        mask_to_str(mask_parts)
-                    )
-                )
-            index_reads_seen += 1
-            if index_reads_seen == 1:
-                # first barcode
-                if len1 == read_len:
-                    new_mask.append([("i", len1)])
-                elif len1 > read_len:
-                    new_mask.append([("i", read_len)])
-                elif len1 < read_len:
-                    new_mask.append([("i", len1), ("n", read_len - len1)])
-            elif index_reads_seen == 2:
-                # second barcode
-                if len2 == read_len:
-                    new_mask.append([("i", len2)])
-                elif len2 > read_len:
-                    new_mask.append([("i", read_len)])
-                elif len2 < read_len:
-                    new_mask.append([("i", len2), ("n", read_len - len2)])
-        else:
-            new_mask.append(read)
-    return new_mask
-
-
-def write_samplesheets(name, filename_template, date, root_mask, assignments):
-    """Write out the sample sheets"""
-    mask_parts = parse_mask(root_mask)
-    max_bclen1 = 0
-    max_bclen2 = 0
-    index_reads_seen = 0
-    for read in mask_parts:
-        read_len = sum(piece[1] for piece in read)
-        is_index_read = any(piece[0] == "i" for piece in read)
-        if is_index_read:
-            index_reads_seen += 1
-            if index_reads_seen == 1:
-                max_bclen1 = read_len
-            if index_reads_seen == 2:
-                max_bclen2 = read_len
-
+    # Trim barcodes to make sure they fit in the read
     for assign in assignments:
         assign["barcode1"] = assign["barcode1"][:max_bclen1]
         assign["barcode2"] = assign["barcode2"][:max_bclen2]
-    # Trim barcodes to make sure they fit in the read
 
     groups = group_assignments(assignments)
 
     for barcode_lengths, assigns in groups.items():
-        new_mask = adjust_mask_for_lengths(mask_parts, *barcode_lengths)
-        header = make_samplesheet_header(name, date)
+        adjusted_mask = mask.adjust_for_barcode_lengths(*barcode_lengths)
+        header = make_samplesheet_header(name, date, adjusted_mask, mismatches)
         body = make_samplesheet_body(assigns)
         samplesheet_contents = header + body
-        filename = filename_template.format(mask=mask_to_str(new_mask))
+        filename = filename_template.format(mask=str(adjusted_mask))
         print(
-            "Writing {filename} with {new_mask}".format(
-                filename=filename, new_mask=mask_to_str(new_mask)
-            )
+            f"Writing {filename} with OverrideCycles={adjusted_mask.to_override_cycles()}"
         )
         with open(filename, "w") as f:
             f.write(samplesheet_contents)
 
 
-def make_samplesheet_body(barcode_assignments: "[dict]") -> str:
+def make_samplesheet_body(barcode_assignments: "list[dict]") -> str:
     """Create samplesheet text from assignments"""
     lines = []
     for ba in barcode_assignments:
+        # bcl-convert format: Lane,Sample_ID,index,index2
         line = ",".join(
             [
                 str(ba["lane"]),
                 ba["sample"],
-                ba["sample"],
                 str(ba["barcode1"]),
                 str(ba["barcode2"]),
-                "",
             ]
         )
         lines.append(line)
@@ -265,6 +369,7 @@ def main(args=sys.argv):
         date=str(datetime.date.today()),
         root_mask=mask,
         assignments=assignments,
+        mismatches=poptions.mismatches,
     )
 
 

--- a/scripts/flowcells/make_samplesheets.py
+++ b/scripts/flowcells/make_samplesheets.py
@@ -114,6 +114,26 @@ class BasesMask:
         return sum(1 for read in self.reads if any(piece[0] == "i" for piece in read))
 
     @property
+    def index_active_states(self) -> list[bool]:
+        """
+        Return active state for each physical index position.
+
+        A physical index slot is identified by containing any 'i' piece (including
+        zero-length ones left by adjust_for_barcode_lengths).  A slot is *active*
+        when it has at least one 'i' piece with length > 0, meaning bcl-convert
+        will actually demultiplex on it.
+
+        Returns a list ordered by physical read position, e.g. [True, False] means
+        Index1 is active and Index2 is masked.
+        """
+        states = []
+        for read in self.reads:
+            if any(piece[0] == "i" for piece in read):
+                active = any(piece[0] == "i" and piece[1] > 0 for piece in read)
+                states.append(active)
+        return states
+
+    @property
     def index_lengths(self) -> tuple[int, int]:
         """
         Return the lengths of index1 and index2.
@@ -160,7 +180,9 @@ class BasesMask:
                     # Barcode fills or exceeds the read
                     new_reads.append([("i", read_len)])
                 else:
-                    # Barcode is shorter, pad with 'n'
+                    # Barcode is shorter (or absent), pad with 'n'.
+                    # Keep ('i', 0) as a zero-length marker so callers can
+                    # distinguish a masked physical index slot from a non-index read.
                     new_reads.append([("i", bc_len), ("n", read_len - bc_len)])
             else:
                 new_reads.append(read)
@@ -250,16 +272,17 @@ def make_samplesheet_header(
     mismatch1 = mismatch_parts[0] if len(mismatch_parts) > 0 else "1"
     mismatch2 = mismatch_parts[1] if len(mismatch_parts) > 1 else mismatch1
 
-    # Build mismatch settings - only include Index2 if there are 2 index reads
-    num_indexes = mask.num_index_reads
-    if num_indexes >= 2:
-        mismatch_settings = (
-            f"BarcodeMismatchesIndex1,{mismatch1}\nBarcodeMismatchesIndex2,{mismatch2}"
-        )
-    elif num_indexes == 1:
-        mismatch_settings = f"BarcodeMismatchesIndex1,{mismatch1}"
-    else:
-        mismatch_settings = ""
+    # Emit BarcodeMismatchesIndexN only for physically active index reads.
+    # bcl-convert uses physical read numbering: Index1 = first index slot in
+    # RunInfo.xml, Index2 = second.  Emitting a mismatch setting for a slot
+    # whose OverrideCycles are all-N causes bcl-convert to error.
+    active = mask.index_active_states
+    mismatch_lines = []
+    if len(active) >= 1 and active[0]:
+        mismatch_lines.append(f"BarcodeMismatchesIndex1,{mismatch1}")
+    if len(active) >= 2 and active[1]:
+        mismatch_lines.append(f"BarcodeMismatchesIndex2,{mismatch2}")
+    mismatch_settings = "\n".join(mismatch_lines)
 
     template = textwrap.dedent("""\
     [Header]

--- a/scripts/flowcells/setup.sh
+++ b/scripts/flowcells/setup.sh
@@ -234,7 +234,7 @@ read -d '' regular_bcl_command  << _REG_BCL_CMD_
       --bcl-input-directory "${illumina_dir}" \\\\
       --output-directory "$fastq_dir" \\\\
       --sample-sheet "${illumina_dir}/SampleSheet.csv" \\\\
-      --fastq-gzip-compression-level 1 \\\\
+      --fastq-gzip-compression-level 4 \\\\
       --bcl-num-conversion-threads     \\\$((SLURM_CPUS_PER_TASK / 2)) \\\\
       --bcl-num-compression-threads    \\\$((SLURM_CPUS_PER_TASK / 2)) \\\\
       --bcl-num-decompression-threads  \\\$((SLURM_CPUS_PER_TASK / 2))
@@ -249,7 +249,7 @@ read -d '' novaseq_bcl_command  << _NOVA_BCL_CMD_
         --bcl-input-directory "${illumina_dir}" \\\\
         --output-directory    "${analysis_dir}/bcl_output/\$fastq_dir" \\\\
         --sample-sheet        "${illumina_dir}/\$samplesheet" \\\\
-        --fastq-gzip-compression-level 1 \\\\
+        --fastq-gzip-compression-level 4 \\\\
         --bcl-num-conversion-threads     \\\$((SLURM_CPUS_PER_TASK / 2)) \\\\
         --bcl-num-compression-threads    \\\$((SLURM_CPUS_PER_TASK / 2)) \\\\
         --bcl-num-decompression-threads  \\\$((SLURM_CPUS_PER_TASK / 2))
@@ -284,7 +284,7 @@ for samplesheet in SampleSheet.withmask*csv ; do
         --output-directory    "${analysis_dir}/bcl_output/\\\$fastq_dir" \\\\
         --sample-sheet        "${illumina_dir}/\$samplesheet" \\\\
         --bcl-only-lane       "\\\$lane" \\\\
-        --fastq-gzip-compression-level 1 \\\\
+        --fastq-gzip-compression-level 4 \\\\
         --bcl-num-conversion-threads     \\\\\$((SLURM_CPUS_PER_TASK / 2)) \\\\
         --bcl-num-compression-threads    \\\\\$((SLURM_CPUS_PER_TASK / 2)) \\\\
         --bcl-num-decompression-threads  \\\\\$((SLURM_CPUS_PER_TASK / 2))
@@ -474,7 +474,7 @@ case $run_type in
       --output-directory "$fastq_dir" \\\\
       --sample-sheet "${illumina_dir}/SampleSheet.csv" \\\\
       --create-fastq-for-index-reads true \\\\
-      --fastq-gzip-compression-level 1
+      --fastq-gzip-compression-level 4
 _U_
     set -e
     ;;
@@ -498,7 +498,7 @@ _U_
       --output-directory "$fastq_dir" \\\\
       --sample-sheet "${illumina_dir}/SampleSheet.csv" \\\\
       --no-lane-splitting true \\\\
-      --fastq-gzip-compression-level 1
+      --fastq-gzip-compression-level 4
 _U_
     set -e
     ;;
@@ -524,7 +524,7 @@ _U_
       --output-directory "$fastq_dir" \\\\
       --sample-sheet "${illumina_dir}/SampleSheet.csv" \\\\
       --no-lane-splitting true \\\\
-      --fastq-gzip-compression-level 1
+      --fastq-gzip-compression-level 4
 _U_
     set -e
     ;;

--- a/scripts/flowcells/setup.sh
+++ b/scripts/flowcells/setup.sh
@@ -325,7 +325,7 @@ case $run_type in
     fastq_dir="$analysis_dir/bcl_output/fastq"  # Written directly to flowcells/bcl_output/, no rsync needed
     bc_flag="--novaseq"
     queue="$DEFAULT_QUEUE"
-    $APX python3 "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 --mismatches "$mismatches" -p processing.json
+    $APX python3 "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 --reverse_barcode2 --mismatches "$mismatches" -p processing.json
     bcl_tasks=1
     submit_bcl2fastq_cmd=$novaseq_submit_command
 ;;
@@ -339,7 +339,7 @@ case $run_type in
     fastq_dir="$analysis_dir/bcl_output/fastq"  # Written directly to flowcells/bcl_output/, no rsync needed
     bc_flag="--novaseq"
     queue="$DEFAULT_QUEUE"
-    $APX python3 "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 --mismatches "$mismatches" -p processing.json
+    $APX python3 "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 --reverse_barcode2 --mismatches "$mismatches" -p processing.json
     bcl_tasks=1
     submit_bcl2fastq_cmd=$novaseq_submit_command
 
@@ -353,7 +353,7 @@ case $run_type in
     fastq_dir="$analysis_dir/bcl_output/fastq"  # Written directly to flowcells/bcl_output/, no rsync needed
     bc_flag="--novaseq"
     queue="$DEFAULT_QUEUE"
-    $APX python3 "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 --mismatches "$mismatches" -p processing.json
+    $APX python3 "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 --reverse_barcode2 --mismatches "$mismatches" -p processing.json
     bcl_tasks=1
     submit_bcl2fastq_cmd=$novaseq_submit_command
 
@@ -367,7 +367,7 @@ case $run_type in
     fastq_dir="$analysis_dir/bcl_output/fastq"  # Written directly to flowcells/bcl_output/, no rsync needed
     bc_flag="--novaseq"
     queue="$DEFAULT_QUEUE"
-    $APX python3 "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 --mismatches "$mismatches" -p processing.json
+    $APX python3 "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 --reverse_barcode2 --mismatches "$mismatches" -p processing.json
     bcl_tasks=1
     submit_bcl2fastq_cmd=$novaseq_submit_command
 
@@ -381,7 +381,7 @@ case $run_type in
     fastq_dir="$analysis_dir/bcl_output/fastq"  # Written directly to flowcells/bcl_output/, no rsync needed
     bc_flag="--novaseq"
     queue="$DEFAULT_QUEUE"
-    $APX python3 "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 --mismatches "$mismatches" -p processing.json
+    $APX python3 "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 --reverse_barcode2 --mismatches "$mismatches" -p processing.json
     bcl_tasks=1
     submit_bcl2fastq_cmd=$novaseq_submit_command
 
@@ -395,7 +395,7 @@ case $run_type in
     fastq_dir="$analysis_dir/bcl_output/fastq"  # Written directly to flowcells/bcl_output/, no rsync needed
     bc_flag="--novaseq"
     queue="$DEFAULT_QUEUE"
-    $APX python3 "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 --mismatches "$mismatches" -p processing.json
+    $APX python3 "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 --reverse_barcode2 --mismatches "$mismatches" -p processing.json
     bcl_tasks=1
     submit_bcl2fastq_cmd=$novaseq_submit_command
 
@@ -410,7 +410,7 @@ case $run_type in
     fastq_dir="$analysis_dir/bcl_output/fastq"  # Written directly to flowcells/bcl_output/, no rsync needed
     bc_flag="--novaseq"
     queue="$DEFAULT_QUEUE"
-    $APX python3 "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 --mismatches "$mismatches" -p processing.json
+    $APX python3 "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 --reverse_barcode2 --mismatches "$mismatches" -p processing.json
     bcl_tasks=1
     unaligned_command=$novaseq_bcl_command
 

--- a/scripts/flowcells/setup.sh
+++ b/scripts/flowcells/setup.sh
@@ -65,7 +65,7 @@ EOF
 }
 
 verbose=
-demux=
+separate_demux_step=
 nosleep=
 while getopts ":hvdxf:" opt ; do
     case $opt in
@@ -77,7 +77,7 @@ while getopts ":hvdxf:" opt ; do
         verbose=true
         ;;
     d)
-        demux=true
+        separate_demux_step=true
         ;;
     x)
         nosleep=true
@@ -105,103 +105,33 @@ if [ -z "$flowcell" ] ; then
 fi
 
 #######################
-# Samplesheet functions
+# Samplesheet generation
 #######################
 
-make_hiseq_samplesheet(){
-  echo "FCID,Lane,SampleID,SampleRef,Index,Description,Control,Recipe,Operator,SampleProject"
-
-  if [ -z "$demux" ] ; then
-    # ( X | tostring) syntax is for non-string fields
-    # Default values (if field is false or null) come after //
-    jq -r --arg flowcell "$flowcell" '
-    .libraries as $l
-    | $l
-    | map( select(.failed == false) )
-    | map( .lane as $num
-    | .barcode_index =
-    if (  $l | map(select( $num  == .lane )) | length == 1 ) then
-      "NoIndex"
-    else
-      .barcode_index
-      end )
-      | .[] | [
-      "FC" + $flowcell,
-      (.lane | tostring),
-      .samplesheet_name,
-      .alignments[0].genome_index // "contam",
-      .barcode_index              // "NoIndex",
-      .cell_type                  // "None"  ,
-      "N",
-      .assay                      // "N/A"   ,
-      "orders",
-      .project
-      ] | join(",") ' "$json"
-    else
-      for i in $(seq 8) ; do
-        echo "FC$flowcell,$i,none,none,GGGGGGGG-GGGGGGGG,none,N,none,none,none"
-      done
+# Generate sample sheets using make_samplesheets.py
+# This creates bcl-convert v2 format sample sheets with OverrideCycles
+# When $separate_demux_step is set, we skip samplesheet generation and use --no-sample-sheet
+generate_samplesheets() {
+  local extra_args=("$@")
+  if [ -n "$separate_demux_step" ] ; then
+    echo "Demux mode: skipping samplesheet generation (will use --no-sample-sheet)"
+    return
+  fi
+  # shellcheck disable=SC2086
+  $APX python3 "$STAMPIPES/scripts/flowcells/make_samplesheets.py" \
+    -p "$json" \
+    --mismatches "$mismatches" \
+    --filename "SampleSheet.withmask.{mask}.csv" \
+    "${extra_args[@]}"
+  # TODO: Don't like this....
+  # Create a symlink to the first samplesheet as SampleSheet.csv for simple cases
+  if [ ! -e SampleSheet.csv ] ; then
+    local first_sheet
+    first_sheet=$(ls SampleSheet.withmask.*.csv 2>/dev/null | head -n1)
+    if [ -n "$first_sheet" ] ; then
+      ln -sf "$first_sheet" SampleSheet.csv
     fi
-
-  }
-
-
-make_nextseq_samplesheet(){
-  name=Stamlab
-  date=$(date '+%m/%d/%Y')
-  cat <<__SHEET__
-[Header]
-Investigator Name,$name
-Project Name,$name
-Experiment Name,$name
-Date,$date
-Workflow,GenerateFASTQ
-
-[Settings]
-
-[Data]
-SampleID,SampleName,index,index2
-none,none,GGGGGGGG,GGGGGGGG
-__SHEET__
-
-if [ -z "$demux" ] ; then
-  # This bit of cryptic magic generates the samplesheet part.
-  jq -r '.libraries[] | select(.failed == false) | [.samplesheet_name,.samplesheet_name,.barcode_index,""] | join(",") ' "$json" \
-    | sed 's/\([ACTG]\+\)-\([ACTG]\+\),$/\1,\2/'  # Changes dual-index barcodes to proper format
-fi
-
-}
-
-# placeholder
-make_miniseq_samplesheet(){
-  name=Stamlab
-  date=$(date '+%m/%d/%Y')
-  cat <<__SHEET__
-[Header]
-Investigator Name,$name
-Project Name,$name
-Experiment Name,$name
-Date,$date
-Workflow,GenerateFASTQ
-
-[Settings]
-
-[Data]
-SampleID,SampleName,index,index2
-none,none,GGGGGGGG,GGGGGGGG
-__SHEET__
-
-if [ -z "$demux" ] ; then
-  # This bit of cryptic magic generates the samplesheet part.
-  jq -r '.libraries[] | select(.failed == false) | [.samplesheet_name,.samplesheet_name,.barcode_index,""] | join(",") ' "$json" \
-    | sed 's/\([ACTG]\+\)-\([ACTG]\+\),$/\1,\2/'  # Changes dual-index barcodes to proper format
-fi
-
-}
-
-# placeholder
-make_miniseq_guideseq_samplesheet(){
-sleep 10
+  fi
 }
 
 ########
@@ -274,7 +204,7 @@ __BCL2FASTQ__
   exit 0
 fi
 
-if [ -z "$demux" ] ; then
+if [ -z "$separate_demux_step" ] ; then
   bcl_mask=$mask
   mismatches=$($APX python3 $STAMPIPES/scripts/flowcells/max_mismatch.py --ignore_failed_lanes --allow_collisions)
   if [ "$has_umi" == "true" ] ; then
@@ -296,32 +226,38 @@ fi
 # read -d '' always exits with status 1, so we ignore error
 # We split threads equally between processing and loading+writing.
 set +e
+# Build samplesheet argument - use --no-sample-sheet for demux mode
+if [ -n "$separate_demux_step" ] ; then
+  samplesheet_arg="--no-sample-sheet true"
+else
+  samplesheet_arg="--sample-sheet \"${illumina_dir}/SampleSheet.csv\""
+fi
+
 read -d '' regular_bcl_command  << _REG_BCL_CMD_
-    PATH=/home/nelsonjs/src/bcl2fastq2/bin/:\$PATH
-    \$APX bcl2fastq \\\\
-      --input-dir "${illumina_dir}/Data/Intensities/BaseCalls" \\\\
-      --use-bases-mask "$bcl_mask" \\\\
-      --output-dir "$fastq_dir" \\\\
-      --barcode-mismatches "$mismatches" \\\\
-      --writing-threads        0                       \\\\
-      --loading-threads        \\\$SLURM_CPUS_PER_TASK \\\\
-      --processing-threads     \\\$SLURM_CPUS_PER_TASK
+    module load bcl-convert/4.4.6
+    bcl-convert \\\\
+      --bcl-input-directory "${illumina_dir}" \\\\
+      --output-directory "$fastq_dir" \\\\
+      $samplesheet_arg \\\\
+      --fastq-gzip-compression-level 1 \\\\
+      --bcl-num-conversion-threads     \\\$((SLURM_CPUS_PER_TASK / 2)) \\\\
+      --bcl-num-compression-threads    \\\$((SLURM_CPUS_PER_TASK / 2)) \\\\
+      --bcl-num-decompression-threads  \\\$((SLURM_CPUS_PER_TASK / 2))
 _REG_BCL_CMD_
 
 read -d '' novaseq_bcl_command  << _NOVA_BCL_CMD_
-    PATH=/home/nelsonjs/src/bcl2fastq2/bin/:\$PATH
+    module load bcl-convert/4.4.6
     for samplesheet in SampleSheet.withmask*csv ; do
       bcl_mask=\$(sed 's/.*withmask\\.//;s/\\.csv//' <<< \$samplesheet)
       fastq_dir=\$(sed 's/,/-/g' <<< "fastq-withmask-\$bcl_mask")
-      \$APX bcl2fastq \\\\
-        --input-dir          "${illumina_dir}/Data/Intensities/BaseCalls" \\\\
-        --output-dir         "${illumina_dir}/\$fastq_dir"                \\\\
-        --use-bases-mask     "\$bcl_mask"                                 \\\\
-        --barcode-mismatches "$mismatches"                                \\\\
-        --sample-sheet       "${illumina_dir}/\$samplesheet"              \\\\
-        --writing-threads    0                                            \\\\
-        --loading-threads    \\\$SLURM_CPUS_PER_TASK                      \\\\
-        --processing-threads \\\$SLURM_CPUS_PER_TASK
+      bcl-convert \\\\
+        --bcl-input-directory "${illumina_dir}" \\\\
+        --output-directory    "${illumina_dir}/\$fastq_dir" \\\\
+        --sample-sheet        "${illumina_dir}/\$samplesheet" \\\\
+        --fastq-gzip-compression-level 1 \\\\
+        --bcl-num-conversion-threads     \\\$((SLURM_CPUS_PER_TASK / 2)) \\\\
+        --bcl-num-compression-threads    \\\$((SLURM_CPUS_PER_TASK / 2)) \\\\
+        --bcl-num-decompression-threads  \\\$((SLURM_CPUS_PER_TASK / 2))
     done
 _NOVA_BCL_CMD_
 
@@ -331,7 +267,7 @@ queue="$DEFAULT_QUEUE"
 
 # This is a variant where we submit one job for each lane
 read -d '' novaseq_submit_command <<_NOVA_SUBMIT_CMD_
-# Run bcl2fastq in parallel, for each samplesheet and lane
+# Run bcl-convert in parallel, for each samplesheet and lane
 PROCESSING=
 for samplesheet in SampleSheet.withmask*csv ; do
   for lane in {1..8} ; do
@@ -347,17 +283,16 @@ for samplesheet in SampleSheet.withmask*csv ; do
 #!/bin/bash
       set -x -e -o pipefail
       cd "${illumina_dir}"
-      PATH=/home/nelsonjs/src/bcl2fastq2/bin/:\$PATH
-      \$APX bcl2fastq \\\\
-        --input-dir          "${illumina_dir}/Data/Intensities/BaseCalls" \\\\
-        --output-dir         "${illumina_dir}/\\\$fastq_dir"              \\\\
-        --use-bases-mask     "\\\$bcl_mask"                               \\\\
-        --tiles              "s_\\\$lane"                                 \\\\
-        --barcode-mismatches "$mismatches"                                \\\\
-        --sample-sheet       "${illumina_dir}/\$samplesheet"              \\\\
-        --writing-threads    0                                            \\\\
-        --loading-threads    \\\\\$SLURM_CPUS_PER_TASK                    \\\\
-        --processing-threads \\\\\$SLURM_CPUS_PER_TASK
+      module load bcl-convert/4.4.6
+      bcl-convert \\\\
+        --bcl-input-directory "${illumina_dir}" \\\\
+        --output-directory    "${illumina_dir}/\\\$fastq_dir" \\\\
+        --sample-sheet        "${illumina_dir}/\$samplesheet" \\\\
+        --bcl-only-lane       "\\\$lane" \\\\
+        --fastq-gzip-compression-level 1 \\\\
+        --bcl-num-conversion-threads     \\\\\$((SLURM_CPUS_PER_TASK / 2)) \\\\
+        --bcl-num-compression-threads    \\\\\$((SLURM_CPUS_PER_TASK / 2)) \\\\
+        --bcl-num-decompression-threads  \\\\\$((SLURM_CPUS_PER_TASK / 2))
 __FASTQ__
 )
     PROCESSING="\$PROCESSING,\$bcl_jobid"
@@ -395,9 +330,8 @@ case $run_type in
     fastq_dir="$illumina_dir/fastq"  # Lack of trailing slash is important for rsync!
     bc_flag="--novaseq"
     queue="$DEFAULT_QUEUE"
-    $APX python "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 -p processing.json
+    $APX python3 "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 --mismatches "$mismatches" -p processing.json
     bcl_tasks=1
-    #unaligned_command=$novaseq_bcl_command
     submit_bcl2fastq_cmd=$novaseq_submit_command
 ;;
 
@@ -410,9 +344,8 @@ case $run_type in
     fastq_dir="$illumina_dir/fastq"  # Lack of trailing slash is important for rsync!
     bc_flag="--novaseq"
     queue="$DEFAULT_QUEUE"
-    $APX python "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 -p processing.json
+    $APX python3 "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 --mismatches "$mismatches" -p processing.json
     bcl_tasks=1
-    #unaligned_command=$novaseq_bcl_command
     submit_bcl2fastq_cmd=$novaseq_submit_command
 
 ;;
@@ -425,9 +358,8 @@ case $run_type in
     fastq_dir="$illumina_dir/fastq"  # Lack of trailing slash is important for rsync!
     bc_flag="--novaseq"
     queue="$DEFAULT_QUEUE"
-    $APX python "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 -p processing.json
+    $APX python3 "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 --mismatches "$mismatches" -p processing.json
     bcl_tasks=1
-    #unaligned_command=$novaseq_bcl_command
     submit_bcl2fastq_cmd=$novaseq_submit_command
 
 ;;
@@ -440,9 +372,8 @@ case $run_type in
     fastq_dir="$illumina_dir/fastq"  # Lack of trailing slash is important for rsync!
     bc_flag="--novaseq"
     queue="$DEFAULT_QUEUE"
-    $APX python "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 -p processing.json
+    $APX python3 "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 --mismatches "$mismatches" -p processing.json
     bcl_tasks=1
-    #unaligned_command=$novaseq_bcl_command
     submit_bcl2fastq_cmd=$novaseq_submit_command
 
 ;;
@@ -455,9 +386,8 @@ case $run_type in
     fastq_dir="$illumina_dir/fastq"  # Lack of trailing slash is important for rsync!
     bc_flag="--novaseq"
     queue="$DEFAULT_QUEUE"
-    $APX python "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 -p processing.json
+    $APX python3 "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 --mismatches "$mismatches" -p processing.json
     bcl_tasks=1
-    #unaligned_command=$novaseq_bcl_command
     submit_bcl2fastq_cmd=$novaseq_submit_command
 
 ;;
@@ -470,9 +400,8 @@ case $run_type in
     fastq_dir="$illumina_dir/fastq"  # Lack of trailing slash is important for rsync!
     bc_flag="--novaseq"
     queue="$DEFAULT_QUEUE"
-    $APX python "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 -p processing.json
+    $APX python3 "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 --mismatches "$mismatches" -p processing.json
     bcl_tasks=1
-    #unaligned_command=$novaseq_bcl_command
     submit_bcl2fastq_cmd=$novaseq_submit_command
 
 ;;
@@ -486,7 +415,7 @@ case $run_type in
     fastq_dir="$illumina_dir/fastq"  # Lack of trailing slash is important for rsync!
     bc_flag="--novaseq"
     queue="$DEFAULT_QUEUE"
-    $APX python "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 -p processing.json
+    $APX python3 "$STAMPIPES/scripts/flowcells/make_samplesheets.py" --reverse_barcode1 --mismatches "$mismatches" -p processing.json
     bcl_tasks=1
     unaligned_command=$novaseq_bcl_command
 
@@ -500,7 +429,7 @@ case $run_type in
     fastq_dir="$illumina_dir/fastq"  # Lack of trailing slash is important for rsync!
     bc_flag="--nextseq"
     queue="$SLOW_QUEUE"
-    make_nextseq_samplesheet > SampleSheet.csv
+    generate_samplesheets
     bcl_tasks=1
     unaligned_command=$regular_bcl_command
     ;;
@@ -512,7 +441,7 @@ case $run_type in
     fastq_dir="$illumina_dir/fastq"  # Lack of trailing slash is important for rsync!
     bc_flag="--hiseq4k"
     queue="$SLOW_QUEUE"
-    make_nextseq_samplesheet > SampleSheet.csv
+    generate_samplesheets
     bcl_tasks=1-8
     unaligned_command=$regular_bcl_command
   ;;
@@ -525,7 +454,7 @@ case $run_type in
     fastq_dir="$illumina_dir/fastq"  # Lack of trailing slash is important for rsync!
     bc_flag="--miniseq"
     queue="$SLOW_QUEUE"
-    make_nextseq_samplesheet > SampleSheet.csv
+    generate_samplesheets
     bcl_tasks=1
     unaligned_command=$regular_bcl_command
     ;;
@@ -544,10 +473,13 @@ case $run_type in
     bcl_tasks=1
     set +e
     read -d '' unaligned_command  << _U_
-    \$APX bcl2fastq \\\\
-      --input-dir "${illumina_dir}/Data/Intensities/BaseCalls" \\\\
-      --output-dir "$fastq_dir" \\\\
-      --create-fastq-for-index-reads
+    module load bcl-convert/4.4.6
+    bcl-convert \\\\
+      --bcl-input-directory "${illumina_dir}" \\\\
+      --output-directory "$fastq_dir" \\\\
+      --sample-sheet "${illumina_dir}/SampleSheet.csv" \\\\
+      --create-fastq-for-index-reads true \\\\
+      --fastq-gzip-compression-level 1
 _U_
     set -e
     ;;
@@ -561,14 +493,17 @@ _U_
     bc_flag="--miniseq"
     queue="$SLOW_QUEUE"
     minidemux="True"
-    make_miniseq_samplesheet > SampleSheet.csv
+    generate_samplesheets
     bcl_tasks=1
     set +e
     read -d '' unaligned_command  << _U_
-    \$APX bcl2fastq \\\\
-      --input-dir "${illumina_dir}/Data/Intensities/BaseCalls" \\\\
-      --output-dir "$fastq_dir" \\\\
-      --no-lane-splitting
+    module load bcl-convert/4.4.6
+    bcl-convert \\\\
+      --bcl-input-directory "${illumina_dir}" \\\\
+      --output-directory "$fastq_dir" \\\\
+      $samplesheet_arg \\\\
+      --no-lane-splitting true \\\\
+      --fastq-gzip-compression-level 1
 _U_
     set -e
     ;;
@@ -588,10 +523,13 @@ _U_
     bcl_tasks=1
     set +e
     read -d '' unaligned_command  << _U_
-    \$APX bcl2fastq \\\\
-      --input-dir "${illumina_dir}/Data/Intensities/BaseCalls" \\\\
-      --output-dir "$fastq_dir" \\\\
-      --no-lane-splitting
+    module load bcl-convert/4.4.6
+    bcl-convert \\\\
+      --bcl-input-directory "${illumina_dir}" \\\\
+      --output-directory "$fastq_dir" \\\\
+      --sample-sheet "${illumina_dir}/SampleSheet.csv" \\\\
+      --no-lane-splitting true \\\\
+      --fastq-gzip-compression-level 1
 _U_
     set -e
     ;;
@@ -600,31 +538,7 @@ _U_
     echo "Regular HiSeq 2500 run detected"
     echo "HiSeq 2500 processing not supported on the new cluster! (Does not have old version of bcl2fastq)"
     exit 2
-    #parallel_env=""
-    #link_command='#no linking to do'
-    #samplesheet=$(pwd)/Data/Intensities/BaseCalls/SampleSheet.csv
-    #mkdir -p $(dirname "$samplesheet")
-    #make_hiseq_samplesheet > "$samplesheet"
-    #fastq_dir="$illumina_dir/Unaligned/"  # Trailing slash is important for rsync!
-    #bc_flag="--hiseq"
-    #bcl_tasks=1
-
-    #set +e
-    #read -d '' unaligned_command <<_U_
-    #if [ ! -e "$fastq_dir" ] ; then
-    #        configureBclToFastq.pl \\\\
-    #          --mismatches "$mismatches" \\\\
-    #          --output-dir "$fastq_dir" \\\\
-    #          --fastq-cluster-count 16000000 \\\\
-    #          --with-failed-reads --sample-sheet $samplesheet \\\\
-    #          --use-bases-mask "$bcl_mask"  \\\\
-    #          --input-dir "$illumina_dir/Data/Intensities/BaseCalls"
-    #fi
-
-    #cd "$fastq_dir"
-    #qmake -now no -cwd -q all.q -V -- -j "$NODES"
-#_U_
-    #set -e
+    # If you need the older code - check git history
     ;;
 *)
     echo "Unrecognized run type '$run_type'"
@@ -633,7 +547,7 @@ _U_
 esac
 
 copy_from_dir="$fastq_dir"
-if [ -n "$demux" ] ; then
+if [ -n "$separate_demux_step" ] ; then
   copy_from_dir="$(pwd)/Demultiplexed/"
   # obsolete now?
   demux_cmd="$STAMPIPES/scripts/flowcells/demux_flowcell.sh -i $fastq_dir -o $copy_from_dir -p $json -q $queue -m $dmx_mismatches"
@@ -662,7 +576,7 @@ $(declare -f set_cluster_vars)
 set_cluster_vars
 
 [[ -s "$MODULELOAD" ]] && source "$MODULELOAD"
-module load bcl2fastq2/2.17.1.14
+module load bcl-convert/4.4.6
 \$LOAD_APPTAINER
 [[ -s "$PYTHON3_ACTIVATE" ]] && source "$PYTHON3_ACTIVATE"
 source $STAMPIPES/scripts/lims/api_functions.sh
@@ -684,7 +598,7 @@ while [ ! -e "$illumina_dir/CopyComplete.txt" ] ; do sleep 60 ; done
 lims_patch "flowcell_run/$flowcell_id/" "status=https://lims.stamlab.org/api/flowcell_run_status/3/"
 lims_patch "flowcell_run/$flowcell_id/" "folder_name=${PWD##*/}"
 
-# bcl2fastq
+# bcl-convert
 bcl_jobid=\$(sbatch --export=ALL -J "u-$flowcell" -o "u-$flowcell.o%A" -e "u-$flowcell.e%A" \$dependencies_barcodes --partition=$queue --ntasks=1 --cpus-per-task=20 --mem-per-cpu=8000 --parsable --oversubscribe <<'__FASTQ__'
 #!/bin/bash
 
@@ -706,12 +620,12 @@ __BCL2FASTQ__
 
 else # If not miniseq
 
-# Default (slow) bcl2fastq cmd
+# Default (slow) bcl-convert cmd
 if [[ -z "$submit_bcl2fastq_cmd" ]] ; then
   # If we haven't created the submit command yet, wrap up the unaligned_command
   # This is the "old" way of submitting one job that does the whole flowcell
   submit_bcl2fastq_cmd=<<__SUBMIT_BCL2FASTQ_CMD__
-# bcl2fastq
+# bcl-convert
 bcl_jobid=\$(sbatch --export=ALL -J "u-$flowcell" -o "u-$flowcell.o%A" -e "u-$flowcell.e%A"  --partition=$queue --ntasks=1 --cpus-per-task=20 --mem-per-cpu=8000 --parsable --oversubscribe <<'__FASTQ__'
 #!/bin/bash
 set -x -e -o pipefail
@@ -720,7 +634,7 @@ cd "$illumina_dir"
 $unaligned_command
 __FASTQ__
 )
-# Wait for bcl2fastq to complete
+# Wait for bcl-convert to complete
 if [[ -n \$bcl_jobid ]]; then
    bcl_dependency=\$(echo \$bcl_jobid | sed -e 's/^/--dependency=afterok:/g')
 fi
@@ -732,7 +646,7 @@ cat > run_bcl2fastq.sh <<__BCL2FASTQ__
 #!/bin/bash
 
 [[ -s "$MODULELOAD" ]] && source "$MODULELOAD"
-module load bcl2fastq2/2.20.0.422
+module load bcl-convert/4.4.6
 [[ -s "$PYTHON3_ACTIVATE" ]] && source "$PYTHON3_ACTIVATE"
 source $STAMPIPES/scripts/lims/api_functions.sh
 
@@ -797,7 +711,7 @@ $(declare -f on_new_cluster)
 $(declare -f set_cluster_vars)
 set_cluster_vars
 
-if [[ -n "$demux" ]] ; then
+if [[ -n "$separate_demux_step" ]] ; then
 # demultiplex
 if [ -d "$fastq_dir.L001" ] ; then
   inputfiles=(\$(find $fastq_dir.L00[1-9] -name "*Undetermined_*fastq.gz" -size +0 ))


### PR DESCRIPTION
Switches to use bcl-convert, instead of the deprecated program bcl2fastq.

A couple of notes:

* Preliminary timing information indicates about a 1.3x speedup (30% faster).
* I've primarily tested these on NovaSeq flowcells - it's possible that there may be a miniseq configuration or similar that needs the barcodes reversed in setup.sh.
* I would not be surprised if we will not be able to run bcl-convert on very old flowcell types (pre hiseq-2500).
* We wouldn't be able to run this on the old cluster, as it supports neither apptainer nor the bcl-convert module.

The associated stats & reports are generally more useful, but they are different. We don't have any automated systems that were reading these, as far as I know, so the change should be fine.